### PR TITLE
docker: Use comfystream base image as base for comfyui pipeline

### DIFF
--- a/docs/runner-docker.md
+++ b/docs/runner-docker.md
@@ -9,7 +9,7 @@ This folder contains Dockerfiles for pipelines supported by the Livepeer AI netw
 
 All pipeline-specific containers are built on top of the base container found in the main [runner](../) folder and on [Docker Hub](https://hub.docker.com/r/livepeer/ai-runner). The base container includes the minimum dependencies to run any pipeline, while pipeline-specific containers add the necessary dependencies for their respective pipelines. This structure allows for faster build times, less dependency bloat, and easier maintenance.
 
-### Steps to Build a Pipeline-Specific Container
+### To build a pipeline-specific container (non-ComfyUI)
 
 To build a pipeline-specific container, you need to build the base container first. The base container is tagged as `base`, and the pipeline-specific container is built from the Dockerfile in the pipeline-specific folder. For example, to build the `segment-anything-2` pipeline-specific container, follow these steps:
 
@@ -35,33 +35,43 @@ To build a pipeline-specific container, you need to build the base container fir
 
    This command builds the `segment-anything-2` pipeline-specific container using the Dockerfile located at [docker/Dockerfile.segment_anything_2](docker/Dockerfile.segment_anything_2) and tags it as `livepeer/ai-runner:segment-anything-2`.
 
-### ComfyStream integration with Depth-Anything
+### To build the ComfyUI based pipeline
 
-1. Build Docker image
-```
-export PIPELINE=comfyui
-docker build -t livepeer/ai-runner:live-base -f docker/Dockerfile.live-base .
-docker build -t livepeer/ai-runner:live-base-${PIPELINE} -f docker/Dockerfile.live-base-${PIPELINE} .
-docker build -t livepeer/ai-runner:live-app-${PIPELINE} -f docker/Dockerfile.live-app__PIPELINE__ --build-arg PIPELINE=${PIPELINE} .
+We provide a convenient build script that simplifies the build and run process. The script is located at `runner/build.sh` and supports multiple operations:
+
+```bash
+./build.sh [command]
 ```
 
-2. Download Depth Anything model
-```
-./dl_checkpoints --live
+Available commands:
+- `base` - Build only the base ComfyUI image
+- `app` - Build only the application image
+- `models` - Download required model checkpoints and build TensorRT engines
+- `run` - Run the ComfyUI container
+- `all` - Execute all build steps in sequence (recommended for first-time setup)
+
+For a complete first-time setup, simply run:
+
+```bash
+cd ai-worker/runner
+./build.sh all
 ```
 
-3. Build Depth Anything Engine
-```
-./dl_checkpoints --tensorrt
+This will:
+1. Build the base ComfyUI image
+2. Build the application image
+3. Download required model checkpoints
+4. Build TensorRT engines
+
+Once built, you can start the container anytime with:
+
+```bash
+./build.sh run
 ```
 
-4. Start Docker container
+This will start the container with all necessary configurations, including GPU support, port mapping (8000), and required environment variables.
 
-```
-docker run -it --rm --name video-to-video --gpus all -p 8000:8000 -v ./models:/models -e PIPELINE=live-video-to-video -e MODEL_ID=comfyui livepeer/ai-runner:live-app-comfyui
-```
-
-### Noop pipeline for local testing (works on Darwin as well)
+### To build the no-op pipeline for local testing (works on Darwin as well)
 
 1. Build Docker images
 ```

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -40,7 +40,7 @@ async def main(*, http_port: int, stream_protocol: str, subscribe_url: str, publ
         api = await start_http_server(http_port, streamer)
 
         tasks: List[asyncio.Task] = []
-        tasks.append(streamer.wait())
+        tasks.append(asyncio.create_task(streamer.wait()))
         tasks.append(asyncio.create_task(block_until_signal([signal.SIGINT, signal.SIGTERM])))
 
         await asyncio.wait(tasks,

--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -13,34 +13,224 @@ from comfystream.client import ComfyStreamClient
 import logging
 
 COMFY_UI_WORKSPACE_ENV = "COMFY_UI_WORKSPACE"
-DEFAULT_WORKFLOW_JSON = {
-    "1": {
-        "inputs": {
-            "images": ["2", 0]
-        },
-        "class_type": "SaveTensor",
-        "_meta": {
-            "title": "SaveTensor"
-        }
+DEFAULT_WORKFLOW_JSON = json.loads("""
+{
+  "1": {
+    "inputs": {
+      "image": "DALL·E 2024-11-15 10.15.49 - An anime-style character standing in a modern office space. The character is a young professional, dressed in a stylish business outfit, with medium-l.jpg",
+      "upload": "image"
     },
-    "2": {
-        "inputs": {
-            "engine": "depth_anything_vitl14-fp16.engine",
-            "images": ["3", 0]
-        },
-        "class_type": "DepthAnythingTensorrt",
-        "_meta": {
-            "title": "Depth Anything Tensorrt"
-        }
-    },
-    "3": {
-        "inputs": {},
-        "class_type": "LoadTensor",
-        "_meta": {
-            "title": "LoadTensor"
-        }
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
     }
+  },
+  "2": {
+    "inputs": {
+      "engine": "depth_anything_vitl14-fp16.engine",
+      "images": [
+        "1",
+        0
+      ]
+    },
+    "class_type": "DepthAnythingTensorrt",
+    "_meta": {
+      "title": "Depth Anything Tensorrt"
+    }
+  },
+  "3": {
+    "inputs": {
+      "unet_name": "static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine",
+      "model_type": "SD15"
+    },
+    "class_type": "TensorRTLoader",
+    "_meta": {
+      "title": "TensorRT Loader"
+    }
+  },
+  "4": {
+    "inputs": {
+      "ckpt_name": "SD1.5/dreamshaper-8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "5": {
+    "inputs": {
+      "text": "the hulk",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "seed": 945236422600751,
+      "steps": 1,
+      "cfg": 1,
+      "sampler_name": "lcm",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "3",
+        0
+      ],
+      "positive": [
+        "9",
+        0
+      ],
+      "negative": [
+        "9",
+        1
+      ],
+      "latent_image": [
+        "16",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "8": {
+    "inputs": {
+      "control_net_name": "control_v11f1p_sd15_depth_fp16.safetensors"
+    },
+    "class_type": "ControlNetLoader",
+    "_meta": {
+      "title": "Load ControlNet Model"
+    }
+  },
+  "9": {
+    "inputs": {
+      "strength": 1,
+      "start_percent": 0,
+      "end_percent": 1,
+      "positive": [
+        "5",
+        0
+      ],
+      "negative": [
+        "6",
+        0
+      ],
+      "control_net": [
+        "10",
+        0
+      ],
+      "image": [
+        "2",
+        0
+      ]
+    },
+    "class_type": "ControlNetApplyAdvanced",
+    "_meta": {
+      "title": "Apply ControlNet"
+    }
+  },
+  "10": {
+    "inputs": {
+      "backend": "inductor",
+      "fullgraph": false,
+      "mode": "reduce-overhead",
+      "controlnet": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "TorchCompileLoadControlNet",
+    "_meta": {
+      "title": "TorchCompileLoadControlNet"
+    }
+  },
+  "11": {
+    "inputs": {
+      "vae_name": "taesd"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "13": {
+    "inputs": {
+      "backend": "inductor",
+      "fullgraph": true,
+      "mode": "reduce-overhead",
+      "compile_encoder": true,
+      "compile_decoder": true,
+      "vae": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "TorchCompileLoadVAE",
+    "_meta": {
+      "title": "TorchCompileLoadVAE"
+    }
+  },
+  "14": {
+    "inputs": {
+      "samples": [
+        "7",
+        0
+      ],
+      "vae": [
+        "13",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "15": {
+    "inputs": {
+      "images": [
+        "14",
+        0
+      ]
+    },
+    "class_type": "PreviewImage",
+    "_meta": {
+      "title": "Preview Image"
+    }
+  },
+  "16": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  }
 }
+""")
 
 
 class ComfyUIParams(BaseModel):

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -236,7 +236,7 @@ class PipelineStreamer:
             gone_stale = (
                 time_since_last_output > time_since_last_input
                 and time_since_last_output > 60
-                and time_since_reload > 60
+                and time_since_reload > 240
             )
             if time_since_last_input > 5 and not gone_stale:
                 # nothing to do if we're not sending inputs

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -102,7 +102,8 @@ async def run_publish(publish_url: str, image_generator, get_metadata):
         # TODO use asyncio.TaskGroup once all pipelines are on Python 3.11+
         live_tasks = set()
         live_tasks_lock = threading.Lock()
-        def schedule_callback(coro: asyncio.coroutine, pipe_name):
+
+        def schedule_callback(coro, pipe_name):
             task = loop.create_task(coro)
             with live_tasks_lock:
                 live_tasks.add(task)

--- a/runner/build.sh
+++ b/runner/build.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e  # Exit on any error
+
+# Configuration
+export PIPELINE=comfyui
+BASE_IMAGE="livepeer/ai-runner:live-base-comfyui"
+APP_IMAGE="livepeer/ai-runner:live-app-${PIPELINE}"
+
+# Build base image
+build_base() {
+    echo "Building base image..."
+    docker build -t ${BASE_IMAGE} -f docker/Dockerfile.live-base-comfyui .
+}
+
+# Build application image
+build_app() {
+    echo "Building application image..."
+    docker build -t ${APP_IMAGE} -f docker/Dockerfile.live-app__PIPELINE__ --build-arg PIPELINE=${PIPELINE} .
+}
+
+# Download checkpoints
+download_checkpoints() {
+    echo "Downloading checkpoints..."
+    ./dl_checkpoints.sh --live
+    ./dl_checkpoints.sh --tensorrt
+}
+
+# Run the application
+run_app() {
+    echo "Running the application..."
+    docker run -it --rm \
+        --name video-to-video \
+        --gpus all \
+        -p 8000:8000 \
+        -v ./models:/models \
+        -e PIPELINE=live-video-to-video \
+        -e MODEL_ID=comfyui \
+        ${APP_IMAGE}
+}
+
+# Target: build-all
+build_all() {
+    build_base
+    build_app
+    download_checkpoints
+}
+
+# Parse command line arguments
+case "$1" in
+    "base")
+        build_base
+        ;;
+    "app")
+        build_app
+        ;;
+    "models")
+        download_checkpoints
+        ;;
+    "run")
+        run_app
+        ;;
+    "all")
+        build_all
+        ;;
+    *)
+        echo "Usage: $0 {base|app|checkpoints|run|all}"
+        echo "  base       - Build base image only"
+        echo "  app        - Build application image only"
+        echo "  models     - Download model checkpoints"
+        echo "  run        - Run the application"
+        echo "  all        - Build everything in sequence"
+        exit 1
+        ;;
+esac
+
+
+

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -99,15 +99,6 @@ function download_live_models() {
                  adduser $(id -u -n) && \
                  chown -R $(id -u -n):$(id -g -n) /models" \
         || (echo "failed ComfyUI setup_models.py"; return 1)
-
-    # TODO: Remove the script download with curl. It should already come in the base image once eliteprox/comfystream#1 is merged.
-    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
-        bash -c "cd /comfystream/src/comfystream/scripts && \
-                 curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
-                 python ./build_trt.py \
-                --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
-        || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 
 function build_tensorrt_models() {
@@ -138,6 +129,15 @@ function build_tensorrt_models() {
                 chown -R $(id -u -n):$(id -g -n) /models
                 " \
         || (echo "failed streamdiffusion tensorrt"; return 1)
+
+    # TODO: Remove the script download with curl. It should already come in the base image once eliteprox/comfystream#1 is merged.
+    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
+        bash -c "cd /comfystream/src/comfystream/scripts && \
+                 curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
+                 python ./build_trt.py \
+                --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
+                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
+        || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 
 # Download models with a restrictive license.

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ComfyUI image configuration
+AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
+
 # Checks HF_TOKEN and huggingface-cli login status and throw warning if not authenticated.
 check_hf_auth() {
     if [ -z "$HF_TOKEN" ] && [ "$(huggingface-cli whoami)" = "Not logged in" ]; then
@@ -89,7 +92,6 @@ function download_live_models() {
     huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 
     # ComfyUI
-    AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
     # docker pull $AI_RUNNER_COMFYUI_IMAGE
     # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
     docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -100,11 +100,11 @@ function download_live_models() {
                  chown -R $(id -u -n):$(id -g -n) /models" \
         || (echo "failed ComfyUI setup_models.py"; return 1)
 
-    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines livepeer/ai-runner:live-base-comfyui \
-        bash -c "cd / && \
-                 source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
-                 export PYTHONPATH=\"/ComfyUI:$PYTHONPATH\" && \    
-                 python /workspace/src/comfystream/scripts/build_trt.py \
+    # TODO: Remove the script download with curl. It should already come in the base image once eliteprox/comfystream#1 is merged.
+    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
+        bash -c "cd /comfystream/src/comfystream/scripts && \
+                 curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
+                 python ./build_trt.py \
                 --model /models/ComfyUI--models/unet/dreamshaper-8-dmd-1kstep.safetensors \
                 --out-engine /models/ComfyUI--models/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
         || (echo "failed ComfyUI build_trt.py"; return 1)

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -136,7 +136,7 @@ function build_tensorrt_models() {
                  curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
                  python ./build_trt.py \
                 --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
+                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-512-w-512_00001_.engine" \
         || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -136,7 +136,9 @@ function build_tensorrt_models() {
                  curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
                  python ./build_trt.py \
                 --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-512-w-512_00001_.engine" \
+                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-512-w-512_00001_.engine && \
+                 adduser $(id -u -n) && \
+                 chown -R $(id -u -n):$(id -g -n) /models" \
         || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -132,6 +132,12 @@ function build_tensorrt_models() {
 
     # TODO: Remove the script download with curl. It should already come in the base image once eliteprox/comfystream#1 is merged.
     docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
+    bash -c "cd /ComfyUI/models/tensorrt/depth-anything && \
+                python /ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
+                adduser $(id -u -n) && \
+                chown -R $(id -u -n):$(id -g -n) /models" \
+    || (echo "failed ComfyUI Depth-Anything-Tensorrt"; return 1)
+    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
         bash -c "cd /comfystream/src/comfystream/scripts && \
                  curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
                  python ./build_trt.py \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -90,7 +90,7 @@ function download_live_models() {
 
     # ComfyUI
     AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
-    docker pull $AI_RUNNER_COMFYUI_IMAGE
+    # docker pull $AI_RUNNER_COMFYUI_IMAGE
     # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
     docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
     docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -99,6 +99,15 @@ function download_live_models() {
                  adduser $(id -u -n) && \
                  chown -R $(id -u -n):$(id -g -n) /models" \
         || (echo "failed ComfyUI setup_models.py"; return 1)
+
+    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines livepeer/ai-runner:live-base-comfyui \
+        bash -c "cd / && \
+                 source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
+                 export PYTHONPATH=\"/ComfyUI:$PYTHONPATH\" && \    
+                 python /workspace/src/comfystream/scripts/build_trt.py \
+                --model /models/ComfyUI--models/checkpoints/SD1.5/dreamshaper-8.safetensors \
+                --out-engine /models/ComfyUI--models/tensorrt/" \
+        || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 
 function build_tensorrt_models() {

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -105,8 +105,8 @@ function download_live_models() {
                  source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
                  export PYTHONPATH=\"/ComfyUI:$PYTHONPATH\" && \    
                  python /workspace/src/comfystream/scripts/build_trt.py \
-                --model /models/ComfyUI--models/checkpoints/SD1.5/dreamshaper-8.safetensors \
-                --out-engine /models/ComfyUI--models/tensorrt/" \
+                --model /models/ComfyUI--models/unet/dreamshaper-8-dmd-1kstep.safetensors \
+                --out-engine /models/ComfyUI--models/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
         || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -87,35 +87,18 @@ function download_all_models() {
 function download_live_models() {
     huggingface-cli download KBlueLeaf/kohaku-v2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
     huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-    huggingface-cli download yuvraj108c/Depth-Anything-Onnx --include depth_anything_vitl14.onnx --local-dir models/ComfyUI--models/Depth-Anything-Onnx
-    download_sam2_checkpoints
-    download_florence2_checkpoints
-    download_stream_diffusion_checkpoints
-    download_stream_diffusion_loras
-    huggingface-cli download Kijai/LivePortrait_safetensors --local-dir models/ComfyUI--models/livePortrait
-}
 
-function download_sam2_checkpoints() {
-    huggingface-cli download facebook/sam2-hiera-tiny --local-dir models/ComfyUI--models/sam2--checkpoints/facebook--sam2-hiera-tiny
-    huggingface-cli download facebook/sam2-hiera-small --local-dir models/ComfyUI--models/sam2--checkpoints/facebook--sam2-hiera-small
-    huggingface-cli download facebook/sam2-hiera-large --local-dir models/ComfyUI--models/sam2--checkpoints/facebook--sam2-hiera-large
-}
-
-function download_florence2_checkpoints() {
-    huggingface-cli download microsoft/Florence-2-large --local-dir models/ComfyUI--models/LLM/Florence-2-large --include "*.py" "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data"
-    huggingface-cli download microsoft/Florence-2-large-ft --local-dir models/ComfyUI--models/LLM/Florence-2-large-ft --include "*.py" "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data"
-    huggingface-cli download microsoft/Florence-2-base --local-dir models/ComfyUI--models/LLM/Florence-2-base --include "*.py" "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data"
-    huggingface-cli download microsoft/Florence-2-base-ft --local-dir models/ComfyUI--models/LLM/Florence-2-base-ft --include "*.py" "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data"
-}
-
-function download_stream_diffusion_checkpoints() {
-    # ComfyUI_StreamDiffusion is loading single file safetensors from /models/checkpoints
-    huggingface-cli download pschroedl/comfystream_checkpoints --local-dir models/ComfyUI--models/checkpoints --include "*.safetensors"
-}
-
-function download_stream_diffusion_loras() {
-    # ral-dissolve-sd15 LoRA
-    huggingface-cli download pschroedl/comfystream_loras --local-dir models/ComfyUI--models/loras --include "*.safetensors"
+    # ComfyUI
+    AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
+    docker pull $AI_RUNNER_COMFYUI_IMAGE
+    # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
+    docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
+    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
+        bash -c "cd /comfystream && \
+                 python src/comfystream/scripts/setup_models.py --workspace /ComfyUI && \
+                 adduser $(id -u -n) && \
+                 chown -R $(id -u -n):$(id -g -n) /models" \
+        || (echo "failed ComfyUI setup_models.py"; return 1)
 }
 
 function build_tensorrt_models() {
@@ -146,20 +129,6 @@ function build_tensorrt_models() {
                 chown -R $(id -u -n):$(id -g -n) /models
                 " \
         || (echo "failed streamdiffusion tensorrt"; return 1)
-
-    # ComfyUI (only DepthAnything for now)
-    AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
-    docker pull $AI_RUNNER_COMFYUI_IMAGE
-    # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
-    docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
-    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
-        bash -c "cd /comfyui/models/Depth-Anything-Onnx && \
-                    python /comfyui/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
-                    mkdir -p /comfyui/models/tensorrt/depth-anything && \
-                    mv *.engine /comfyui/models/tensorrt/depth-anything && \
-                    adduser $(id -u -n) && \
-                    chown -R $(id -u -n):$(id -g -n) /models" \
-        || (echo "failed ComfyUI tensorrt"; return 1)
 }
 
 # Download models with a restrictive license.
@@ -225,7 +194,7 @@ echo "Starting livepeer AI subnet model downloader..."
 echo "Creating 'models' directory in the current working directory..."
 mkdir -p models
 mkdir -p models/checkpoints
-mkdir -p models/StreamDiffusion--engines models/ComfyUI--models models/ComfyUI--models/sam2--checkpoints models/ComfyUI--models/checkpoints
+mkdir -p models/StreamDiffusion--engines models/ComfyUI--models models/ComfyUI--output
 
 # Ensure 'huggingface-cli' is installed.
 echo "Checking if 'huggingface-cli' is installed..."

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -136,7 +136,7 @@ function build_tensorrt_models() {
                  curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
                  python ./build_trt.py \
                 --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-512-w-512_00001_.engine && \
+                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\\\$stat-b-1-h-512-w-512_00001_.engine && \
                  adduser $(id -u -n) && \
                  chown -R $(id -u -n):$(id -g -n) /models" \
         || (echo "failed ComfyUI build_trt.py"; return 1)

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -106,7 +106,7 @@ function download_live_models() {
                  curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
                  python ./build_trt.py \
                 --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /ComfyUI/models/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
+                --out-engine /ComfyUI/output/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
         || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -93,7 +93,7 @@ function download_live_models() {
     # docker pull $AI_RUNNER_COMFYUI_IMAGE
     # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
     docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
-    docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
+    docker run --rm -v ./models:/models --gpus all -l ComfyUI-Setup-Models $AI_RUNNER_COMFYUI_IMAGE \
         bash -c "cd /comfystream && \
                  python src/comfystream/scripts/setup_models.py --workspace /ComfyUI && \
                  adduser $(id -u -n) && \
@@ -105,8 +105,8 @@ function download_live_models() {
         bash -c "cd /comfystream/src/comfystream/scripts && \
                  curl -O https://raw.githubusercontent.com/pschroedl/comfystream/refs/heads/10_29/build_trt/src/comfystream/scripts/build_trt.py && \
                  python ./build_trt.py \
-                --model /models/ComfyUI--models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /models/ComfyUI--models/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
+                --model /ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
+                --out-engine /ComfyUI/models/tensorrt/static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine" \
         || (echo "failed ComfyUI build_trt.py"; return 1)
 }
 

--- a/runner/docker/Dockerfile.audio_to_text
+++ b/runner/docker/Dockerfile.audio_to_text
@@ -3,14 +3,17 @@ FROM ${BASE_IMAGE}
 
 # Install CUDA Toolkit to enable flash attention.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends cuda-toolkit-12-1 && \
+    apt-get install -y --no-install-recommends \
+    cuda-toolkit-12-1 \
+    g++ && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir \
+    ninja \
     transformers==4.43.3 \
     peft \
     deepcache \
-    flash_attn \
+    flash_attn==2.5.6 \
     pynvml
 
 # Override base working directory to ensure the correct working directory.

--- a/runner/docker/Dockerfile.live-app__PIPELINE__
+++ b/runner/docker/Dockerfile.live-app__PIPELINE__
@@ -13,6 +13,8 @@ RUN apt-get update && apt-get install -y \
 # Install any additional Python packages
 COPY requirements.live-ai.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
+# TODO: Figure out a way to have this in requirements file
+RUN pip install --no-cache-dir triton==3.1.0
 
 # Set environment variables
 ENV MAX_WORKERS=1

--- a/runner/docker/Dockerfile.live-app__PIPELINE__
+++ b/runner/docker/Dockerfile.live-app__PIPELINE__
@@ -29,4 +29,8 @@ COPY bench.py /app/bench.py
 
 WORKDIR /app
 
+# Dirty hack to remove excessive logging before this PR is merged
+# https://github.com/hiddenswitch/ComfyUI/pull/28
+RUN sed -i 's/logging.info(f"Loaded {to_load}")//' /miniconda3/envs/comfystream/lib/python3.11/site-packages/comfy/model_management.py
+
 CMD ["uvicorn", "app.main:app", "--log-config", "app/cfg/uvicorn_logging_config.json", "--host", "0.0.0.0", "--port", "8000"]

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -79,3 +79,9 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV COMFY_UI_WORKSPACE="/ComfyUI"
 RUN ln -s /models/ComfyUI--models /ComfyUI/models
 RUN ln -s /models/ComfyUI--models/output /ComfyUI/output
+
+# Ensure all the next RUN commands are run in the comfystream conda environment
+RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc
+SHELL ["/bin/bash", "-c"]
+# Ensure the app run from CMD is also in the comfystream conda environment (just wrap in bash and it will run the .bashrc above)
+ENTRYPOINT ["bash", "-c", "exec /opt/nvidia/nvidia_entrypoint.sh \"$@\"", "--"]

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -84,7 +84,7 @@ RUN ln -s /models/ComfyUI--output /ComfyUI/output
 RUN git clone https://github.com/pschroedl/comfystream.git /workspace && \
     cd /workspace && \
     git fetch origin && \
-    git checkout 75913bfcc5d41b0e65fdc0274b667668a4f80792
+    git checkout c143654af1a78264303f90d67fc2d59a6275f02e
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -84,7 +84,7 @@ RUN ln -s /models/ComfyUI--output /ComfyUI/output
 RUN git clone https://github.com/pschroedl/comfystream.git /workspace && \
     cd /workspace && \
     git fetch origin && \
-    git checkout 3e29033fad4ae893af2ed7b6f8b6082fe88a8460
+    git checkout 5f0d4729311571fce34c121489256b5f8d3d3c1c
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -84,7 +84,7 @@ RUN ln -s /models/ComfyUI--output /ComfyUI/output
 RUN git clone https://github.com/pschroedl/comfystream.git /comfystream && \
     cd /comfystream && \
     git fetch origin && \
-    git checkout 10_29/built_trt
+    git checkout 10_29/build_trt
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -81,10 +81,10 @@ RUN ln -s /models/ComfyUI--models /ComfyUI/models
 RUN ln -s /models/ComfyUI--output /ComfyUI/output
 
 # TODO: Remove. This should come from the base image.
-RUN git clone https://github.com/pschroedl/comfystream.git /comfystream && \
-    cd /comfystream && \
+RUN git clone https://github.com/pschroedl/comfystream.git /workspace && \
+    cd /workspace && \
     git fetch origin && \
-    git checkout 10_29/build_trt
+    git checkout 3e29033fad4ae893af2ed7b6f8b6082fe88a8460
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -78,7 +78,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/ComfyUI"
 RUN ln -s /models/ComfyUI--models /ComfyUI/models
-RUN ln -s /models/ComfyUI--models/output /ComfyUI/output
+RUN ln -s /models/ComfyUI--output /ComfyUI/output
 
 # Ensure all the next RUN commands are run in the comfystream conda environment
 RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=eliteencoder/comfyui-base:latest
+ARG BASE_IMAGE=livepeer/comfyui-base:latest
 FROM ${BASE_IMAGE}
 
 # -----------------------------------------------------------------------------
@@ -77,15 +77,9 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/ComfyUI"
+ENV PYTHONPATH=/ComfyUI:${PYTHONPATH}
 RUN ln -s /models/ComfyUI--models /ComfyUI/models
 RUN ln -s /models/ComfyUI--output /ComfyUI/output
-
-# TODO: Remove. This should come from the base image.
-RUN git clone https://github.com/pschroedl/comfystream.git /workspace && \
-    cd /workspace && \
-    git fetch origin && \
-    git checkout 10_29/build_trt
-
 
 # Ensure all the next RUN commands are run in the comfystream conda environment
 RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -82,7 +82,9 @@ RUN rm -rf /ComfyUI/models && ln -s /models/ComfyUI--models /ComfyUI/models
 RUN rm -rf /ComfyUI/output && ln -s /models/ComfyUI--output /ComfyUI/output
 
 # Ensure all the next RUN commands are run in the comfystream conda environment
-RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc
+RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> /conda_activate.sh && \
+    chmod +x /conda_activate.sh
+ENV BASH_ENV=/conda_activate.sh
 SHELL ["/bin/bash", "-c"]
 # Ensure the app run from CMD is also in the comfystream conda environment (just wrap in bash and it will run the .bashrc above)
 ENTRYPOINT ["bash", "-c", "exec /opt/nvidia/nvidia_entrypoint.sh \"$@\"", "--"]

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -84,7 +84,7 @@ RUN ln -s /models/ComfyUI--output /ComfyUI/output
 RUN git clone https://github.com/pschroedl/comfystream.git /workspace && \
     cd /workspace && \
     git fetch origin && \
-    git checkout 5f0d4729311571fce34c121489256b5f8d3d3c1c
+    git checkout 75913bfcc5d41b0e65fdc0274b667668a4f80792
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -1,85 +1,79 @@
-ARG BASE_IMAGE=livepeer/ai-runner:live-base
+ARG BASE_IMAGE=eliteencoder/comfyui-base:latest
 FROM ${BASE_IMAGE}
 
-# Create directory for ComfyUI custom nodes and models
-RUN mkdir -p /comfyui/custom_nodes
+# -----------------------------------------------------------------------------
+# live-base: This section was copied from live-base since we don't use it as base image above
+# -----------------------------------------------------------------------------
 
-# Install required Python version
-ARG PYTHON_VERSION=3.10
-RUN pyenv install $PYTHON_VERSION && \
-    pyenv global $PYTHON_VERSION && \
-    pyenv rehash
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
-# Upgrade pip and install required packages
-ARG PIP_VERSION=23.3.2
-ENV PIP_PREFER_BINARY=1
-RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 wheel==0.43.0
+# Install prerequisites
+RUN apt-get update && \
+    apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git runit libzmq3-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install ComfyUI-Depth-Anything-Tensorrt Node (https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt)
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt.git && \
-    cd ComfyUI-Depth-Anything-Tensorrt && \
-    pip install -r requirements.txt
+# Keep python installation from base image
 
-# Install ComfyUI_RyanOnTheInside (https://github.com/ryanontheinside/ComfyUI_RyanOnTheInside.git)
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/pschroedl/ComfyUI_RyanOnTheInside.git && \
-    cd ComfyUI_RyanOnTheInside && \
-    git checkout c5592719d5188cb6bba81287a8af123637eadf79 && \
-    pip install -r requirements.txt
+# Install ffmpeg
 
-# Install ComfyUI-Misc-Effects ( Starburst ) (https://github.com/ryanontheinside/ComfyUI-Misc-Effects.git)
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/ryanontheinside/ComfyUI-Misc-Effects.git && \
-    cd ComfyUI-Misc-Effects && \
-    git checkout c6b360c78611134c3723388170475eb4898ff6b7
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf automake build-essential cmake git-core libtool pkg-config wget \
+    nasm yasm zlib1g-dev libpng-dev libx264-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN pip install torch==2.5.1 torchvision torchaudio tqdm nvidia-ml-py==12.560.30
+# Set up environment variables
+ENV NV_CODEC_HEADERS=/usr/local/cuda/include/ffnvcodec/
+RUN git clone -b n12.2.72.0 --depth 1 https://git.videolan.org/git/ffmpeg/nv-codec-headers.git && \
+    cd nv-codec-headers && \
+    make && \
+    make install && \
+    cd .. && rm -rf nv-codec-headers
 
-# Install comfystream (which includes ComfyUI)
-RUN pip install git+https://github.com/yondonfu/comfystream.git
-RUN git clone https://github.com/yondonfu/comfystream.git && \
-    cd comfystream && \
-    pip install -r requirements.txt && \
-    cp -r nodes/tensor_utils /comfyui/custom_nodes/ 
+# Clone the FFmpeg repository and checkout the latest release
+RUN git clone --branch n7.0.2 --depth 1 https://github.com/FFmpeg/FFmpeg.git ffmpeg
 
-# Install ComfyUI-SAM2-Realtime (https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git)
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git && \
-    cd ComfyUI-SAM2-Realtime && \
-    git checkout 4f587443fb2808c4b5b303afcd7ec3ec3e0fbd08 && \
-    pip install -r requirements.txt
+# Build FFmpeg with static linking and the desired hardware-accelerated features
+RUN cd ffmpeg && \
+    ./configure --prefix=/compiled \
+    --pkg-config-flags="--static" \
+    --extra-cflags="-I/ffmpeg_build/include -I/usr/local/cuda/include" \
+    --extra-ldflags="-L/ffmpeg_build/lib -L/usr/local/cuda/lib64" \
+    --extra-libs="-lpthread -lm" \
+    --enable-nonfree \
+    --enable-cuda-nvcc \
+    --enable-cuda \
+    --enable-libnpp \
+    --enable-cuvid \
+    --enable-nvenc \
+    --enable-nvdec \
+    --enable-static \
+    --enable-gpl \
+    --enable-libx264 \
+    --disable-shared \
+    --disable-debug \
+    --disable-doc && \
+    make -j$(nproc) && \
+    make install && \
+    make distclean
 
-# Install ComfyUI-Florence2-Vision (https://github.com/ad-astra-video/ComfyUI-Florence2-Vision.git)
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/ad-astra-video/ComfyUI-Florence2-Vision.git && \
-    cd ComfyUI-Florence2-Vision && \
-    git checkout 0c624e61b6606801751bd41d93a09abe9844bea7 && \
-    pip install -r requirements.txt
+# Copy the compiled FFmpeg binaries to /usr/local
+RUN cp -R /compiled/* /usr/local/
 
-# Install ComfyUI-StreamDiffusion (https://github.com/pschroedl/ComfyUI-StreamDiffusion.git)
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/pschroedl/ComfyUI-StreamDiffusion.git && \
-    cd ComfyUI-StreamDiffusion && \
-    git checkout f93b98aa9f20ab46c23d149ad208d497cd496579 && \
-    pip install -r requirements.txt
+# Clean up APT cache to reduce image size
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install ComfyUI-LivePortraitKJ Node (https://github.com/kijai/ComfyUI-LivePortraitKJ)
-RUN pip install diffusers==0.30.1
-RUN cd /comfyui/custom_nodes && \
-    git clone https://github.com/kijai/ComfyUI-LivePortraitKJ.git && \
-    cd ComfyUI-LivePortraitKJ && \
-    git checkout 4d9dc6205b793ffd0fb319816136d9b8c0dbfdff && \
-    pip install -r requirements.txt
-# Install ComfyUI-load-image-from-url Node (https://github.com/tsogzark/ComfyUI-load-image-from-url.git)
-RUN cd /comfyui/custom_nodes && \
-git clone https://github.com/tsogzark/ComfyUI-load-image-from-url.git
+# -----------------------------------------------------------------------------
+# live-base: End of section
+# -----------------------------------------------------------------------------
 
+# TODO: Delete if not needed
 # Upgrade TensorRT to 10.6.0
-RUN pip uninstall -y tensorrt && \
-    pip install tensorrt==10.6.0
+# RUN pip uninstall -y tensorrt && \
+#     pip install tensorrt==10.6.0
 
 # Set up ComfyUI workspace
-ENV COMFY_UI_WORKSPACE="/comfyui"
-RUN ln -s /models/ComfyUI--models /comfyui/models
-# TODO: Consider linking the custom nodes directory as well and set those up in the host, similar to the models directory
+ENV COMFY_UI_WORKSPACE="/ComfyUI"

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -22,7 +22,7 @@ RUN apt-get update && \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf automake build-essential cmake git-core libtool pkg-config wget \
-    nasm yasm zlib1g-dev libpng-dev libx264-dev && \
+    nasm yasm zlib1g-dev libpng-dev libx264-dev libopus-dev libfdk-aac-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Set up environment variables
@@ -34,28 +34,28 @@ RUN git clone -b n12.2.72.0 --depth 1 https://git.videolan.org/git/ffmpeg/nv-cod
     cd .. && rm -rf nv-codec-headers
 
 # Clone the FFmpeg repository and checkout the latest release
-RUN git clone --branch n7.0.2 --depth 1 https://github.com/FFmpeg/FFmpeg.git ffmpeg
+RUN git clone --branch n7.1 --depth 1 https://github.com/FFmpeg/FFmpeg.git ffmpeg
 
-# Build FFmpeg with static linking and the desired hardware-accelerated features
+# Build FFmpeg with shared libraries and hardware acceleration
 RUN cd ffmpeg && \
     ./configure --prefix=/compiled \
-    --pkg-config-flags="--static" \
-    --extra-cflags="-I/ffmpeg_build/include -I/usr/local/cuda/include" \
-    --extra-ldflags="-L/ffmpeg_build/lib -L/usr/local/cuda/lib64" \
-    --extra-libs="-lpthread -lm" \
-    --enable-nonfree \
-    --enable-cuda-nvcc \
-    --enable-cuda \
-    --enable-libnpp \
-    --enable-cuvid \
-    --enable-nvenc \
-    --enable-nvdec \
-    --enable-static \
-    --enable-gpl \
-    --enable-libx264 \
-    --disable-shared \
-    --disable-debug \
-    --disable-doc && \
+                --extra-cflags="-I/ffmpeg_build/include -I/usr/local/cuda/include" \
+                --extra-ldflags="-L/ffmpeg_build/lib -L/usr/local/cuda/lib64" \
+                --enable-nonfree \
+                --enable-cuda-nvcc \
+                --enable-cuda \
+                --enable-libnpp \
+                --enable-cuvid \
+                --enable-nvenc \
+                --enable-nvdec \
+                --enable-gpl \
+                --enable-shared \
+                --disable-static \
+                --enable-libx264 \
+                --enable-libopus \
+                --enable-libfdk-aac \
+                --disable-debug \
+                --disable-doc && \
     make -j$(nproc) && \
     make install && \
     make distclean

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -80,6 +80,9 @@ ENV COMFY_UI_WORKSPACE="/ComfyUI"
 RUN ln -s /models/ComfyUI--models /ComfyUI/models
 RUN ln -s /models/ComfyUI--output /ComfyUI/output
 
+# TODO: Remove. This should come from the base image.
+RUN git clone https://github.com/yondonfu/comfystream.git /comfystream
+
 # Ensure all the next RUN commands are run in the comfystream conda environment
 RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc
 SHELL ["/bin/bash", "-c"]

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -78,8 +78,8 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/ComfyUI"
 ENV PYTHONPATH=/ComfyUI:${PYTHONPATH}
-RUN ln -s /models/ComfyUI--models /ComfyUI/models
-RUN ln -s /models/ComfyUI--output /ComfyUI/output
+RUN rm -rf /ComfyUI/models && ln -s /models/ComfyUI--models /ComfyUI/models
+RUN rm -rf /ComfyUI/output && ln -s /models/ComfyUI--output /ComfyUI/output
 
 # Ensure all the next RUN commands are run in the comfystream conda environment
 RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -81,10 +81,10 @@ RUN ln -s /models/ComfyUI--models /ComfyUI/models
 RUN ln -s /models/ComfyUI--output /ComfyUI/output
 
 # TODO: Remove. This should come from the base image.
-RUN git clone https://github.com/yondonfu/comfystream.git /comfystream && \
+RUN git clone https://github.com/pschroedl/comfystream.git /comfystream && \
     cd /comfystream && \
-    git fetch origin pull/20/head:comfystream-base-image && \
-    git checkout comfystream-base-image
+    git fetch origin && \
+    git checkout 10_29/built_trt
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -81,7 +81,11 @@ RUN ln -s /models/ComfyUI--models /ComfyUI/models
 RUN ln -s /models/ComfyUI--output /ComfyUI/output
 
 # TODO: Remove. This should come from the base image.
-RUN git clone https://github.com/yondonfu/comfystream.git /comfystream
+RUN git clone https://github.com/yondonfu/comfystream.git /comfystream && \
+    cd /comfystream && \
+    git fetch origin pull/20/head:comfystream-base-image && \
+    git checkout comfystream-base-image
+
 
 # Ensure all the next RUN commands are run in the comfystream conda environment
 RUN echo "source /miniconda3/etc/profile.d/conda.sh && conda activate comfystream" >> ~/.bashrc

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -77,3 +77,5 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/ComfyUI"
+RUN ln -s /models/ComfyUI--models /ComfyUI/models
+RUN ln -s /models/ComfyUI--models/output /ComfyUI/output

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -84,7 +84,7 @@ RUN ln -s /models/ComfyUI--output /ComfyUI/output
 RUN git clone https://github.com/pschroedl/comfystream.git /workspace && \
     cd /workspace && \
     git fetch origin && \
-    git checkout c143654af1a78264303f90d67fc2d59a6275f02e
+    git checkout 10_29/build_trt
 
 
 # Ensure all the next RUN commands are run in the comfystream conda environment

--- a/runner/docker/Dockerfile.text_to_speech
+++ b/runner/docker/Dockerfile.text_to_speech
@@ -3,16 +3,19 @@ FROM ${BASE_IMAGE}
 
 # Install CUDA Toolkit to enable flash attention.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends cuda-toolkit-12-1 && \
+    apt-get install -y --no-install-recommends \
+    cuda-toolkit-12-1 \
+    g++ && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir \
+    ninja \
     transformers==4.43.3 \
     peft \
     deepcache \
     soundfile \
     g2p-en \
-    flash_attn \
+    flash_attn==2.5.6 \
     git+https://github.com/huggingface/parler-tts.git@5d0aca9753ab74ded179732f5bd797f7a8c6f8ee
 
 # Override base working directory to ensure the correct working directory.

--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -6,7 +6,7 @@ Pillow==10.3.0
 python-multipart==0.0.9
 uvicorn==0.30.0
 huggingface_hub==0.23.2
-triton==3.1.0
+triton>=2.1.0
 peft==0.11.1
 deepcache==0.1.1
 safetensors==0.4.3

--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -6,7 +6,7 @@ Pillow==10.3.0
 python-multipart==0.0.9
 uvicorn==0.30.0
 huggingface_hub==0.23.2
-triton>=2.1.0
+triton==3.1.0
 peft==0.11.1
 deepcache==0.1.1
 safetensors==0.4.3


### PR DESCRIPTION
This implements the [task](https://www.notion.so/livepeer/Migrate-ai-runner-docker-to-comfystream-base-image-1890a348568780c1ae9ef2ee26fced82?pvs=4) for reusing `comfystream` base docker image
to avoid setting up a separate environment altogether for the `comfyui` ai-runner.