### PR TITLE
workflows: disable streamdiffusion builds temporarily

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline: [streamdiffusion, comfyui]
+        pipeline: [comfyui]
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
streamdiffusion dependencies with the new comfyui image needs to be resolved before these builds begin passing. The streamdiffusion pipeline is not required at launch so disabling it temporarily here.