### PR TITLE
fix container monitoring by moving blocking pipeline call to asyncio thread

### DIFF
--- a/runner/app/routes/audio_to_text.py
+++ b/runner/app/routes/audio_to_text.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from typing import Annotated, Dict, Tuple, Union
@@ -155,9 +156,9 @@ async def audio_to_text(
         )
 
     try:
-        return pipeline(
-            audio=audio, return_timestamps=return_timestamps, duration=duration
-        )
+
+        return await asyncio.to_thread(pipeline, audio=audio, return_timestamps=return_timestamps, duration=duration)
+        
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/image_to_image.py
+++ b/runner/app/routes/image_to_image.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import partial
 import logging
 import os
 import random
@@ -182,19 +184,21 @@ async def image_to_image(
     has_nsfw_concept = []
     for seed in seeds:
         try:
-            imgs, nsfw_checks = pipeline(
-                prompt=prompt,
-                image=image,
-                strength=strength,
-                loras=loras,
-                guidance_scale=guidance_scale,
-                image_guidance_scale=image_guidance_scale,
-                negative_prompt=negative_prompt,
-                safety_check=safety_check,
-                seed=seed,
-                num_images_per_prompt=1,
-                num_inference_steps=num_inference_steps,
-            )
+            pipeline_call = partial(pipeline, 
+                                    prompt=prompt,
+                                    image=image,
+                                    strength=strength,
+                                    loras=loras,
+                                    guidance_scale=guidance_scale,
+                                    image_guidance_scale=image_guidance_scale,
+                                    negative_prompt=negative_prompt,
+                                    safety_check=safety_check,
+                                    seed=seed,
+                                    num_images_per_prompt=1,
+                                    num_inference_steps=num_inference_steps,
+                                    scheduler=scheduler
+                                )
+            imgs, nsfw_checks = await asyncio.to_thread(pipeline_call)
         except Exception as e:
             if isinstance(e, torch.cuda.OutOfMemoryError):
                 # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/image_to_text.py
+++ b/runner/app/routes/image_to_text.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from typing import Annotated, Dict, Tuple, Union
@@ -105,7 +106,8 @@ async def image_to_text(
 
     image = Image.open(image.file).convert("RGB")
     try:
-        return ImageToTextResponse(text=pipeline(prompt=prompt, image=image))
+        out = await asyncio.to_thread(pipeline, prompt=prompt, image=image)
+        return ImageToTextResponse(text=out)
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/segment_anything_2.py
+++ b/runner/app/routes/segment_anything_2.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import partial
 import logging
 import os
 from typing import Annotated, Dict, Tuple, Union
@@ -172,16 +174,16 @@ async def segment_anything_2(
 
     try:
         image = Image.open(image.file).convert("RGB")
-        masks, scores, low_res_mask_logits = pipeline(
-            image,
-            point_coords=point_coords,
-            point_labels=point_labels,
-            box=box,
-            mask_input=mask_input,
-            multimask_output=multimask_output,
-            return_logits=return_logits,
-            normalize_coords=normalize_coords,
-        )
+        pipeline_call = partial(pipeline,
+                                image=image,
+                                point_coords=point_coords,
+                                point_labels=point_labels,
+                                box=box,
+                                mask_input=mask_input,
+                                multimask_output=multimask_output,
+                                return_logits=return_logits,
+                                normalize_coords=normalize_coords)
+        masks, scores, low_res_mask_logits = await asyncio.to_thread(pipeline_call)
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/text_to_image.py
+++ b/runner/app/routes/text_to_image.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import random
@@ -196,7 +197,7 @@ async def text_to_image(
         params.seed = seed
         kwargs = {k: v for k, v in params.model_dump().items() if k != "model_id"}
         try:
-            imgs, nsfw_check = pipeline(**kwargs)
+            imgs, nsfw_check = await asyncio.to_thread(pipeline, **kwargs)
         except Exception as e:
             if isinstance(e, torch.cuda.OutOfMemoryError):
                 # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/text_to_speech.py
+++ b/runner/app/routes/text_to_speech.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import time
@@ -127,7 +128,7 @@ async def text_to_speech(
 
     try:
         start = time.time()
-        out = pipeline(params)
+        out = await asyncio.to_thread(pipeline, params)
         logger.info(f"TextToSpeechPipeline took {time.time() - start} seconds.")
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):

--- a/runner/app/routes/upscale.py
+++ b/runner/app/routes/upscale.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import partial
 import logging
 import os
 import random
@@ -126,13 +128,13 @@ async def upscale(
     image = Image.open(image.file).convert("RGB")
 
     try:
-        images, has_nsfw_concept = pipeline(
-            prompt=prompt,
-            image=image,
-            num_inference_steps=num_inference_steps,
-            safety_check=safety_check,
-            seed=seed,
-        )
+        pipeline_call = partial(pipeline,
+                                prompt=prompt,
+                                image=image,
+                                num_inference_steps=num_inference_steps,
+                                safety_check=safety_check,
+                                seed=seed)
+        images, has_nsfw_concept = await asyncio.to_thread(pipeline_call)
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.


### PR DESCRIPTION
This updates the pipeline calls to move to thread in event loop which fixes containers being killed if not responding to the /health checks the ai-worker does in go-livepeer.  

I have seen this on FLUX DEV requests and image-to-video pipeline requests.

It happens sometimes on SFAST initialization as well.  Should we consider moving that to the event loop or move all of the calls to the pipeline functions to the event loop?

See discord thread of report from Orchestrator running image-to-video: https://discord.com/channels/423160867534929930/1338172672152047739/1338586158321504426

cc @victorges @rickstaa 