### PR TITLE
infer.py: Run a single pipeline process for all streams

### DIFF
--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -55,11 +55,11 @@ class StartStreamParams(BaseModel):
     ]
     request_id: Annotated[
         str,
-        Field(..., description="Unique identifier for the request."),
+        Field(default="", description="Unique identifier for the request."),
     ]
     stream_id: Annotated[
         str,
-        Field(..., description="Unique identifier for the stream."),
+        Field(default="", description="Unique identifier for the stream."),
     ]
 
 

--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -48,13 +48,6 @@ class StartStreamParams(BaseModel):
             description="URL for publishing events via Trickle protocol for pipeline status and logs.",
         ),
     ]
-    model_id: Annotated[
-        str,
-        Field(
-            default="",
-            description="Name of the pipeline to run in the live video to video job. Notice that this is named model_id for consistency with other routes, but it does not refer to a Hugging Face model ID. The exact model(s) depends on the pipeline implementation and might be configurable via the `params` argument.",
-        ),
-    ]
     params: Annotated[
         Dict,
         Field(default={}, description="Initial parameters for the pipeline."),

--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -1,17 +1,72 @@
+import asyncio
 import hashlib
 import logging
 import mimetypes
 import os
 import tempfile
 import time
-from typing import cast
+from typing import Optional, cast
 
 from aiohttp import BodyPartReader, web
+from pydantic import BaseModel, Field
+from typing import Annotated, Dict
 
-from streamer import PipelineStreamer
+from streamer import PipelineStreamer, ProcessGuardian
+from streamer.protocol.trickle import TrickleProtocol
 
 TEMP_SUBDIR = "infer_temp"
 MAX_FILE_AGE = 86400  # 1 day
+STREAMER_INPUT_TIMEOUT = 60  # 60s
+
+
+class StartStreamParams(BaseModel):
+    subscribe_url: Annotated[
+        str,
+        Field(
+            ...,
+            description="Source URL of the incoming stream to subscribe to.",
+        ),
+    ]
+    publish_url: Annotated[
+        str,
+        Field(
+            ...,
+            description="Destination URL of the outgoing stream to publish.",
+        ),
+    ]
+    control_url: Annotated[
+        str,
+        Field(
+            default="",
+            description="URL for subscribing via Trickle protocol for updates in the live video-to-video generation params.",
+        ),
+    ]
+    events_url: Annotated[
+        str,
+        Field(
+            default="",
+            description="URL for publishing events via Trickle protocol for pipeline status and logs.",
+        ),
+    ]
+    model_id: Annotated[
+        str,
+        Field(
+            default="",
+            description="Name of the pipeline to run in the live video to video job. Notice that this is named model_id for consistency with other routes, but it does not refer to a Hugging Face model ID. The exact model(s) depends on the pipeline implementation and might be configurable via the `params` argument.",
+        ),
+    ]
+    params: Annotated[
+        Dict,
+        Field(default={}, description="Initial parameters for the pipeline."),
+    ]
+    request_id: Annotated[
+        str,
+        Field(..., description="Unique identifier for the request."),
+    ]
+    stream_id: Annotated[
+        str,
+        Field(..., description="Unique identifier for the stream."),
+    ]
 
 
 def cleanup_old_files(temp_dir):
@@ -25,41 +80,89 @@ def cleanup_old_files(temp_dir):
                 logging.info(f"Removed old file: {file_path}")
 
 
-async def handle_params_update(request):
+async def parse_request_data(request: web.Request, temp_dir: str) -> Dict:
+    if request.content_type.startswith("application/json"):
+        return await request.json()
+    elif request.content_type.startswith("multipart/"):
+        params_data = {}
+        reader = await request.multipart()
+        async for part in reader:
+            if not isinstance(part, BodyPartReader):
+                continue
+            elif part.name == "params":
+                part_data = await part.json()
+                if part_data:
+                    params_data.update(part_data)
+            else:
+                content = await part.read()
+                file_hash = hashlib.md5(content).hexdigest()
+                content_type = part.headers.get(
+                    "Content-Type", "application/octet-stream"
+                )
+                ext = mimetypes.guess_extension(content_type) or ""
+                new_filename = f"{file_hash}{ext}"
+                file_path = os.path.join(temp_dir, new_filename)
+                with open(file_path, "wb") as f:
+                    f.write(content)
+                params_data[part.name] = file_path
+        return params_data
+    else:
+        raise ValueError(f"Unknown content type: {request.content_type}")
+
+
+async def handle_start_stream(request: web.Request):
     try:
-        params = {}
+        process = cast(ProcessGuardian, request.app["process"])
+        prev_streamer = cast(PipelineStreamer, request.app["streamer"])
+        if prev_streamer and prev_streamer.is_running():
+            # Stop the previous streamer before starting a new one
+            try:
+                logging.info("Stopping previous streamer")
+                await prev_streamer.stop(timeout=10)
+            except asyncio.TimeoutError as e:
+                logging.error(f"Timeout stopping streamer: {e}")
+                raise web.HTTPBadRequest(text="Timeout stopping previous streamer")
+
         temp_dir = os.path.join(tempfile.gettempdir(), TEMP_SUBDIR)
         os.makedirs(temp_dir, exist_ok=True)
         cleanup_old_files(temp_dir)
 
-        if request.content_type.startswith("application/json"):
-            params = await request.json()
-        elif request.content_type.startswith("multipart/"):
-            reader = await request.multipart()
+        params_data = await parse_request_data(request, temp_dir)
+        params = StartStreamParams(**params_data)
 
-            async for part in reader:
-                if part.name == "params":
-                    params.update(await part.json())
-                elif isinstance(part, BodyPartReader):
-                    content = await part.read()
+        protocol = TrickleProtocol(
+            params.subscribe_url,
+            params.publish_url,
+            params.control_url,
+            params.events_url,
+        )
+        streamer = PipelineStreamer(
+            protocol,
+            STREAMER_INPUT_TIMEOUT,
+            process,
+            params.request_id,
+            params.stream_id,
+        )
 
-                    file_hash = hashlib.md5(content).hexdigest()
-                    content_type = part.headers.get(
-                        "Content-Type", "application/octet-stream"
-                    )
-                    ext = mimetypes.guess_extension(content_type) or ""
-                    new_filename = f"{file_hash}{ext}"
+        await streamer.start(params.params)
+        request.app["streamer"] = streamer
 
-                    file_path = os.path.join(temp_dir, new_filename)
-                    with open(file_path, "wb") as f:
-                        f.write(content)
+        return web.Response(text="Stream started successfully")
+    except Exception as e:
+        logging.error(f"Error starting stream: {e}")
+        return web.Response(text=f"Error starting stream: {str(e)}", status=400)
 
-                    params[part.name] = file_path
-        else:
-            raise ValueError(f"Unknown content type: {request.content_type}")
 
-        streamer = cast(PipelineStreamer, request.app["streamer"])
-        await streamer.update_params(params)
+async def handle_params_update(request: web.Request):
+    try:
+        temp_dir = os.path.join(tempfile.gettempdir(), TEMP_SUBDIR)
+        os.makedirs(temp_dir, exist_ok=True)
+        cleanup_old_files(temp_dir)
+
+        params = await parse_request_data(request, temp_dir)
+
+        process = cast(ProcessGuardian, request.app["process"])
+        await process.update_params(params)
 
         return web.Response(text="Params updated successfully")
     except Exception as e:
@@ -67,14 +170,19 @@ async def handle_params_update(request):
         return web.Response(text=f"Error updating params: {str(e)}", status=400)
 
 
-async def handle_get_status(request):
-    streamer = cast(PipelineStreamer, request.app["streamer"])
-    status = streamer.get_status()
+async def handle_get_status(request: web.Request):
+    process = cast(ProcessGuardian, request.app["process"])
+    status = process.get_status()
     return web.json_response(status.model_dump())
 
-async def start_http_server(port: int, streamer: PipelineStreamer):
+
+async def start_http_server(
+    port: int, process: ProcessGuardian, streamer: Optional[PipelineStreamer] = None
+):
     app = web.Application()
+    app["process"] = process
     app["streamer"] = streamer
+    app.router.add_post("/api/live-video-to-video", handle_start_stream)
     app.router.add_post("/api/params", handle_params_update)
     app.router.add_get("/api/status", handle_get_status)
 

--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -13,6 +13,7 @@ from typing import Annotated, Dict
 
 from streamer import PipelineStreamer, ProcessGuardian
 from streamer.protocol.trickle import TrickleProtocol
+from streamer.process import config_logging
 
 TEMP_SUBDIR = "infer_temp"
 MAX_FILE_AGE = 86400  # 1 day
@@ -122,6 +123,8 @@ async def handle_start_stream(request: web.Request):
 
         params_data = await parse_request_data(request, temp_dir)
         params = StartStreamParams(**params_data)
+
+        config_logging(request_id=params.request_id, stream_id=params.stream_id)
 
         protocol = TrickleProtocol(
             params.subscribe_url,

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -9,7 +9,7 @@ import traceback
 from typing import List
 import logging
 
-from streamer import PipelineStreamer
+from streamer import PipelineStreamer, ProcessGuardian
 
 # loads neighbouring modules with absolute paths
 infer_root = os.path.abspath(os.path.dirname(__file__))
@@ -21,7 +21,20 @@ from streamer.protocol.trickle import TrickleProtocol
 from streamer.protocol.zeromq import ZeroMQProtocol
 
 
-async def main(*, http_port: int, stream_protocol: str, subscribe_url: str, publish_url: str, control_url: str, events_url: str, pipeline: str, params: dict, input_timeout: int, request_id: str, stream_id: str):
+async def main(
+    *,
+    http_port: int,
+    stream_protocol: str,
+    subscribe_url: str,
+    publish_url: str,
+    control_url: str,
+    events_url: str,
+    pipeline: str,
+    params: dict,
+    input_timeout: int,
+    request_id: str,
+    stream_id: str,
+):
     if stream_protocol == "trickle":
         protocol = TrickleProtocol(subscribe_url, publish_url, control_url, events_url)
     elif stream_protocol == "zeromq":
@@ -33,7 +46,8 @@ async def main(*, http_port: int, stream_protocol: str, subscribe_url: str, publ
     else:
         raise ValueError(f"Unsupported protocol: {stream_protocol}")
 
-    streamer = PipelineStreamer(protocol, pipeline, input_timeout, params or {}, request_id, stream_id)
+    process = ProcessGuardian(pipeline, params or {})
+    streamer = PipelineStreamer(protocol, input_timeout, process, request_id, stream_id)
 
     api = None
     try:
@@ -42,11 +56,11 @@ async def main(*, http_port: int, stream_protocol: str, subscribe_url: str, publ
 
         tasks: List[asyncio.Task] = []
         tasks.append(asyncio.create_task(streamer.wait()))
-        tasks.append(asyncio.create_task(block_until_signal([signal.SIGINT, signal.SIGTERM])))
-
-        await asyncio.wait(tasks,
-            return_when=asyncio.FIRST_COMPLETED
+        tasks.append(
+            asyncio.create_task(block_until_signal([signal.SIGINT, signal.SIGTERM]))
         )
+
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
     except Exception as e:
         logging.error(f"Error starting socket handler or HTTP server: {e}")
         logging.error(f"Stack trace:\n{traceback.format_exc()}")
@@ -68,6 +82,7 @@ async def block_until_signal(sigs: List[signal.Signals]):
         signal.signal(sig, signal_handler)
     return await future
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Infer process to run the AI pipeline")
     parser.add_argument(
@@ -77,49 +92,57 @@ if __name__ == "__main__":
         "--pipeline", type=str, default="streamdiffusion", help="Pipeline to use"
     )
     parser.add_argument(
-        "--initial-params", type=str, default="{}", help="Initial parameters for the pipeline"
+        "--initial-params",
+        type=str,
+        default="{}",
+        help="Initial parameters for the pipeline",
     )
     parser.add_argument(
         "--stream-protocol",
         type=str,
         choices=["trickle", "zeromq"],
         default=os.getenv("STREAM_PROTOCOL", "trickle"),
-        help="Protocol to use for streaming frames in and out. One of: trickle, zeromq"
+        help="Protocol to use for streaming frames in and out. One of: trickle, zeromq",
     )
     parser.add_argument(
-        "--subscribe-url", type=str, required=True, help="URL to subscribe for the input frames (trickle). For zeromq this is the input socket address"
+        "--subscribe-url",
+        type=str,
+        required=True,
+        help="URL to subscribe for the input frames (trickle). For zeromq this is the input socket address",
     )
     parser.add_argument(
-        "--publish-url", type=str, required=True, help="URL to publish output frames (trickle). For zeromq this is the output socket address"
+        "--publish-url",
+        type=str,
+        required=True,
+        help="URL to publish output frames (trickle). For zeromq this is the output socket address",
     )
     parser.add_argument(
-        "--control-url", type=str, help="URL to subscribe for Control API JSON messages to update inference params"
+        "--control-url",
+        type=str,
+        help="URL to subscribe for Control API JSON messages to update inference params",
     )
     parser.add_argument(
-        "--events-url", type=str, help="URL to publish events about pipeline status and logs."
+        "--events-url",
+        type=str,
+        help="URL to publish events about pipeline status and logs.",
     )
     parser.add_argument(
         "--input-timeout",
         type=int,
         default=60,
-        help="Timeout in seconds to wait after input frames stop before shutting down. Set to 0 to disable."
+        help="Timeout in seconds to wait after input frames stop before shutting down. Set to 0 to disable.",
     )
     parser.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        help="Enable verbose (debug) logging"
+        "-v", "--verbose", action="store_true", help="Enable verbose (debug) logging"
     )
     parser.add_argument(
         "--request-id",
         type=str,
         default="",
-        help="The Livepeer request ID associated with this video stream"
+        help="The Livepeer request ID associated with this video stream",
     )
     parser.add_argument(
-        "--stream-id",
-        type=str,
-        default="",
-        help="The Livepeer stream ID"
+        "--stream-id", type=str, default="", help="The Livepeer stream ID"
     )
     args = parser.parse_args()
     try:
@@ -128,9 +151,13 @@ if __name__ == "__main__":
         logging.error(f"Error parsing --initial-params: {e}")
         sys.exit(1)
 
-    config_logging(log_level=logging.DEBUG if args.verbose else logging.INFO, request_id=args.request_id, stream_id=args.stream_id)
+    config_logging(
+        log_level=logging.DEBUG if args.verbose else logging.INFO,
+        request_id=args.request_id,
+        stream_id=args.stream_id,
+    )
     if args.verbose:
-        os.environ['VERBOSE_LOGGING'] = '1' # enable verbose logging in subprocesses
+        os.environ["VERBOSE_LOGGING"] = "1"  # enable verbose logging in subprocesses
 
     try:
         asyncio.run(
@@ -145,7 +172,7 @@ if __name__ == "__main__":
                 params=params,
                 input_timeout=args.input_timeout,
                 request_id=args.request_id,
-                stream_id=args.stream_id
+                stream_id=args.stream_id,
             )
         )
         # We force an exit here to ensure that the process terminates. If any asyncio tasks or
@@ -155,4 +182,3 @@ if __name__ == "__main__":
         logging.error(f"Fatal error in main: {e}")
         logging.error(f"Traceback:\n{''.join(traceback.format_tb(e.__traceback__))}")
         os._exit(1)
-

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -53,6 +53,7 @@ async def main(
 
     api = None
     try:
+        await process.start()
         if streamer:
             await streamer.start(params)
         api = await start_http_server(http_port, process, streamer)

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -75,6 +75,7 @@ async def main(
             await streamer.stop(timeout=5)
         if api:
             await api.cleanup()
+        await process.stop()
 
 
 async def block_until_signal(sigs: List[signal.Signals]):

--- a/runner/app/live/log.py
+++ b/runner/app/live/log.py
@@ -1,15 +1,36 @@
 import logging
 
-def config_logging(log_level: int = logging.INFO, request_id: str = "", stream_id: str = ""):
+
+logger: logging.Logger | None = None
+handler: logging.Handler | None = None
+
+
+def config_logging(*, log_level: int = 0, request_id: str = "", stream_id: str = ""):
+    global logger, handler
+    if logger and handler:
+        if log_level:
+            logger.setLevel(log_level)
+            handler.setLevel(log_level)
+        config_logging_fields(handler, request_id, stream_id)
+        return logger
+
+    handler = logging.StreamHandler()
+    if log_level:
+        handler.setLevel(log_level)
+    config_logging_fields(handler, request_id, stream_id)
+
+    logger = logging.getLogger()  # Root logger
+    if log_level:
+        logger.setLevel(log_level)
+    logger.addHandler(handler)
+    return logger
+
+
+def config_logging_fields(handler: logging.Handler, request_id: str, stream_id: str):
     formatter = logging.Formatter(
         "timestamp=%(asctime)s level=%(levelname)s location=%(filename)s:%(lineno)d:%(funcName)s request_id=%(request_id)s stream_id=%(stream_id)s message=%(message)s",
         defaults={"request_id": request_id, "stream_id": stream_id},
-        datefmt='%Y-%m-%d %H:%M:%S'
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
-    handler = logging.StreamHandler()
+
     handler.setFormatter(formatter)
-    handler.setLevel(log_level)
-    logger = logging.getLogger()  # Root logger
-    logger.setLevel(log_level)
-    logger.addHandler(handler)
-    return logger

--- a/runner/app/live/streamer/__init__.py
+++ b/runner/app/live/streamer/__init__.py
@@ -1,3 +1,4 @@
 from .streamer import PipelineStreamer
+from .process_guardian import ProcessGuardian
 
-__all__ = ["PipelineStreamer"]
+__all__ = ["PipelineStreamer", "ProcessGuardian"]

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -26,7 +26,8 @@ class ProcessGuardian:
 
     async def start(self):
         # Start the pipeline process and initialize timing
-        self.process = PipelineProcess.start(self.pipeline, self.params)
+        # TODO: Fix contextual logging on request_id and stream_id
+        self.process = PipelineProcess.start(self.pipeline, self.params, "", "")
         if self.process is None:
             raise RuntimeError("Failed to start PipelineProcess")
         # Launch the monitor loop as a background task
@@ -159,7 +160,8 @@ class ProcessGuardian:
         # don't call the full start/stop methods since we only want to restart the process
         await self.process.stop()
 
-        self.process = PipelineProcess.start(self.pipeline, self.params)
+        # TODO: Fix contextual logging on request_id and stream_id
+        self.process = PipelineProcess.start(self.pipeline, self.params, "", "")
         self.status.inference_status.restart_count += 1
         self.status.inference_status.last_restart_time = time.time()
         self.status.inference_status.last_restart_logs = restart_logs

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -9,6 +9,10 @@ from .status import PipelineState, PipelineStatus
 
 
 class ProcessGuardian:
+    """
+    This class is responsible for keeping a pipeline process alive and monitoring its status.
+    It also handles the streaming of input and output frames to the pipeline.
+    """
     def __init__(
         self,
         pipeline: str,

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -1,0 +1,264 @@
+import asyncio
+import logging
+import time
+from typing import Awaitable, Callable, Optional
+from trickle import InputFrame, OutputFrame
+
+from .process import PipelineProcess
+from .status import PipelineState, PipelineStatus
+
+
+class ProcessGuardian:
+    def __init__(
+        self,
+        pipeline: str,
+        params: dict,
+    ):
+        self.pipeline = pipeline
+        self.params = params
+        self.monitoring_callback = _noop_callback
+
+        self.process = None
+        self.monitor_task = None
+        self.status = PipelineStatus(
+            pipeline=pipeline, start_time=time.time()
+        ).update_params(params, False)
+
+    async def start(self):
+        # Start the pipeline process and initialize timing
+        self.process = PipelineProcess.start(self.pipeline, self.params)
+        if self.process is None:
+            raise RuntimeError("Failed to start PipelineProcess")
+        # Launch the monitor loop as a background task
+        self.monitor_task = asyncio.create_task(self._monitor_loop())
+
+    async def stop(self):
+        if self.monitor_task:
+            self.monitor_task.cancel()
+            try:
+                await self.monitor_task
+            except asyncio.CancelledError:
+                pass
+            self.monitor_task = None
+        if self.process:
+            await self.process.stop()
+            self.process = None
+
+    async def reset_stream(
+        self, params: dict, monitoring_callback: Callable[[dict], Awaitable[None]]
+    ):
+        self.status = PipelineStatus(
+            pipeline=self.pipeline, start_time=self.status.start_time
+        )
+        self.monitoring_callback = monitoring_callback
+        await self.update_params(params)
+
+    def send_input(self, frame: InputFrame):
+        if not self.process:
+            raise RuntimeError("Process not running")
+        iss = self.status.input_status
+        previous_input_time = max(iss.last_input_time or 0, self.process.start_time)
+        (iss.last_input_time, iss.fps) = calculate_rolling_fps(
+            iss.fps, previous_input_time
+        )
+
+        self.process.send_input(frame)
+
+    async def recv_output(self) -> OutputFrame | None:
+        if not self.process:
+            raise RuntimeError("Process not running")
+        output = await self.process.recv_output()
+
+        oss = self.status.inference_status
+        previous_output_time = max(oss.last_output_time or 0, self.process.start_time)
+        (oss.last_output_time, oss.fps) = calculate_rolling_fps(
+            oss.fps, previous_output_time
+        )
+        return output
+
+    async def update_params(self, params: dict):
+        self.params = params
+        if self.process:
+            self.process.update_params(params)
+        self.status.update_params(params)
+
+        await self.monitoring_callback(
+            {
+                "type": "params_update",
+                "pipeline": self.pipeline,
+                "params": params,
+                "params_hash": self.status.inference_status.last_params_hash,
+                "update_time": self.status.inference_status.last_params_update_time,
+            }
+        )
+
+    def get_status(self, clear_transient: bool = False) -> PipelineStatus:
+        new_state = self._current_state()
+        if new_state != self.status.state:
+            self.status.state = new_state
+            self.status.last_state_update_time = time.time()
+            logging.info(f"Pipeline state changed to {new_state}")
+        status = self.status.model_copy()
+        if clear_transient:
+            # Clear the large transient fields if requested, but do return them
+            self.status.inference_status.last_params = None
+            self.status.inference_status.last_restart_logs = None
+        return status
+
+    def _current_state(self) -> str:
+        current_time = time.time()
+        input = self.status.input_status
+        last_input_time = input.last_input_time or 0
+        time_since_last_input = current_time - last_input_time
+        if time_since_last_input > 60:
+            if time_since_last_input < 90:
+                # streamer should stop automatically after 60s, so give ourselves a 30s grace period to shutdown
+                logging.info(
+                    f"Detected DEGRADED_INPUT during shutdown: time_since_last_input={time_since_last_input:.1f}s"
+                )
+                return PipelineState.DEGRADED_INPUT
+            return PipelineState.OFFLINE
+        elif time_since_last_input > 2 or input.fps < 15:
+            logging.info(
+                f"Detected DEGRADED_INPUT: time_since_last_input={time_since_last_input:.1f}s, fps={input.fps}"
+            )
+            return PipelineState.DEGRADED_INPUT
+
+        inference = self.status.inference_status
+        pipeline_load_time = max(
+            self.status.start_time, inference.last_params_update_time or 0
+        )
+        if inference.last_output_time and current_time - pipeline_load_time < 30:
+            # 30s grace period for the pipeline to start
+            return PipelineState.ONLINE
+
+        delayed_frames = (
+            not inference.last_output_time
+            or current_time - inference.last_output_time > 5
+        )
+        low_fps = inference.fps < min(10, 0.8 * input.fps)
+        recent_restart = (
+            inference.last_restart_time
+            and current_time - inference.last_restart_time < 60
+        )
+        recent_error = (
+            inference.last_error_time and current_time - inference.last_error_time < 15
+        )
+        if delayed_frames or low_fps or recent_restart or recent_error:
+            return PipelineState.DEGRADED_INFERENCE
+
+        return PipelineState.ONLINE
+
+    async def _restart_process(self):
+        if not self.process:
+            raise RuntimeError("Process not started")
+
+        # Capture logs before stopping the process
+        restart_logs = self.process.get_recent_logs()
+        last_error = self.process.get_last_error()
+        # don't call the full start/stop methods since we only want to restart the process
+        await self.process.stop()
+
+        self.process = PipelineProcess.start(self.pipeline, self.params)
+        self.status.inference_status.restart_count += 1
+        self.status.inference_status.last_restart_time = time.time()
+        self.status.inference_status.last_restart_logs = restart_logs
+        if last_error:
+            error_msg, error_time = last_error
+            self.status.inference_status.last_error = error_msg
+            self.status.inference_status.last_error_time = error_time
+
+        await self.monitoring_callback(
+            {
+                "type": "restart",
+                "pipeline": self.pipeline,
+                "restart_count": self.status.inference_status.restart_count,
+                "restart_time": self.status.inference_status.last_restart_time,
+                "restart_logs": restart_logs,
+                "last_error": last_error,
+            }
+        )
+
+        logging.info(
+            f"PipelineProcess restarted. Restart count: {self.status.inference_status.restart_count}"
+        )
+
+    async def _monitor_loop(self):
+        try:
+            while True:
+                await asyncio.sleep(1)
+                if not self.process or self.process.done.is_set():
+                    continue
+
+                last_error = self.process.get_last_error()
+                if last_error:
+                    error_msg, error_time = last_error
+                    self.status.inference_status.last_error = error_msg
+                    self.status.inference_status.last_error_time = error_time
+                    await self.monitoring_callback(
+                        {
+                            "type": "error",
+                            "pipeline": self.pipeline,
+                            "error": error_msg,
+                            "time": error_time,
+                        }
+                    )
+
+                start_time = self.process.start_time
+                current_time = time.time()
+                last_input_time = max(
+                    self.status.input_status.last_input_time or 0, start_time
+                )
+                last_output_time = max(
+                    self.status.inference_status.last_output_time or 0, start_time
+                )
+                last_params_update_time = max(
+                    self.status.inference_status.last_params_update_time or 0,
+                    start_time,
+                )
+
+                time_since_last_input = current_time - last_input_time
+                time_since_last_output = current_time - last_output_time
+                time_since_start = current_time - start_time
+                time_since_last_params = current_time - last_params_update_time
+                time_since_reload = min(time_since_last_params, time_since_start)
+
+                gone_stale = (
+                    time_since_last_output > time_since_last_input
+                    and time_since_last_output > 60
+                    and time_since_reload > 240
+                )
+                if time_since_last_input > 5 and not gone_stale:
+                    # nothing to do if we're not sending inputs
+                    continue
+
+                active_after_reload = time_since_last_output < (time_since_reload - 1)
+                stopped_recently = (
+                    active_after_reload
+                    and time_since_last_output > 5
+                    and time_since_last_output < 60
+                )
+                if stopped_recently or gone_stale:
+                    logging.warning(
+                        "No output received while inputs are being sent. Restarting process."
+                    )
+                    await self._restart_process()
+        except asyncio.CancelledError:
+            pass
+
+
+fps_ema_alpha = 0.0645  # 2 + (30 + 1); to give the most weight to the past 30 frames
+
+
+def calculate_rolling_fps(previous_fps: float, previous_frame_time: float):
+    now = time.time()
+    time_since_last_frame = now - previous_frame_time
+    if time_since_last_frame <= 0:
+        return (now, previous_fps)  # Avoid division by zero or negative time
+    current_fps = 1 / time_since_last_frame
+    new_fps = fps_ema_alpha * current_fps + (1 - fps_ema_alpha) * previous_fps
+    return (now, new_fps)
+
+
+async def _noop_callback(_):
+    pass

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -42,7 +42,9 @@ class PipelineStreamer:
         if self.tasks_supervisor_task:
             raise RuntimeError("Streamer already started")
 
-        await self.process.reset_stream(params, self._emit_monitoring_event)
+        await self.process.reset_stream(
+            self.request_id, self.stream_id, params, self._emit_monitoring_event
+        )
 
         self.stop_event.clear()
         await self.protocol.start()

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -103,11 +103,14 @@ class PipelineStreamer:
             raise RuntimeError("Streamer not started")
         return await self.tasks_supervisor_task
 
+    def is_running(self):
+        return self.tasks_supervisor_task is not None
+
     async def stop(self, *, timeout: float):
         if not self.tasks_supervisor_task:
             raise RuntimeError("Streamer not started")
         self.stop_event.set()
-        await asyncio.wait_for(self.tasks_supervisor_task, timeout)
+        await asyncio.wait_for(asyncio.shield(self.tasks_supervisor_task), timeout)
 
     async def report_status_loop(self):
         next_report = time.time() + status_report_interval

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -3,44 +3,48 @@ import logging
 import os
 import time
 import numpy as np
-from multiprocessing.synchronize import Event
 from typing import AsyncGenerator, Awaitable
 from asyncio import Lock
 
 import cv2
 from PIL import Image
 
-from .process import PipelineProcess
+from .process_guardian import ProcessGuardian
 from .protocol.protocol import StreamProtocol
-from .status import PipelineStatus, PipelineState, timestamp_to_ms
+from .status import timestamp_to_ms
 from trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutput
 
 fps_log_interval = 10
 status_report_interval = 10
 
 class PipelineStreamer:
-    def __init__(self, protocol: StreamProtocol, pipeline: str, input_timeout: int, params: dict, request_id: str, stream_id: str):
+    def __init__(
+        self,
+        protocol: StreamProtocol,
+        input_timeout: int,
+        process: ProcessGuardian,
+        request_id: str,
+        stream_id: str,
+    ):
         self.protocol = protocol
-        self.pipeline = pipeline
-        self.params = params
         self.input_timeout = input_timeout  # 0 means disabled
+        self.process = process
 
-        self.status = PipelineStatus(pipeline=pipeline, start_time=time.time()).update_params(params, False)
         self.stop_event = asyncio.Event()
         self.emit_event_lock = Lock()
-        self.process: PipelineProcess | None = None
 
         self.main_tasks: list[asyncio.Task] = []
         self.tasks_supervisor_task: asyncio.Task | None = None
         self.request_id = request_id
         self.stream_id = stream_id
 
-    async def start(self):
-        if self.process:
+    async def start(self, params: dict):
+        if self.tasks_supervisor_task:
             raise RuntimeError("Streamer already started")
 
+        await self.process.reset_stream(params, self._emit_monitoring_event)
+
         self.stop_event.clear()
-        self.process = PipelineProcess.start(self.pipeline, self.params, self.request_id, self.stream_id)
         await self.protocol.start()
 
         # We need a bunch of concurrent tasks to run the streamer. So we start them all in background and then also start
@@ -48,18 +52,20 @@ class PipelineStreamer:
         self.main_tasks = [
             run_in_background("ingress_loop", self.run_ingress_loop()),
             run_in_background("egress_loop", self.run_egress_loop()),
-            run_in_background("monitor_loop", self.monitor_loop()),
-            run_in_background("report_status_loop", self.report_status_loop())
+            run_in_background("report_status_loop", self.report_status_loop()),
         ]
         # auxiliary tasks that are not critical to the supervisor, but which we want to run
         self.auxiliary_tasks = [
             run_in_background("control_loop", self.run_control_loop())
         ]
-        self.tasks_supervisor_task = run_in_background("tasks_supervisor", self.tasks_supervisor())
+        self.tasks_supervisor_task = run_in_background(
+            "tasks_supervisor", self.tasks_supervisor()
+        )
 
     async def tasks_supervisor(self):
         """Supervises the main tasks and stops everything if either of them return or the stop event is set"""
         try:
+
             async def wait_for_stop():
                 await self.stop_event.wait()
 
@@ -73,72 +79,37 @@ class PipelineStreamer:
 
     async def _do_stop(self):
         """Stops all running tasks and waits for them to exit. To be called only by the supervisor task"""
-        if not self.process:
+        if not self.tasks_supervisor_task:
             raise RuntimeError("Process not started")
 
         # make sure the stop event is set and give running tasks a chance to exit cleanly
         self.stop_event.set()
-        _, pending = await asyncio.wait(self.main_tasks + self.auxiliary_tasks, return_when=asyncio.ALL_COMPLETED, timeout=1)
+        _, pending = await asyncio.wait(
+            self.main_tasks + self.auxiliary_tasks,
+            return_when=asyncio.ALL_COMPLETED,
+            timeout=1,
+        )
         # force cancellation of the remaining tasks
         for task in pending:
             task.cancel()
 
-        await asyncio.gather(self.protocol.stop(), self.process.stop(), return_exceptions=True)
+        await asyncio.gather(
+            self.protocol.stop(), self.process.stop(), return_exceptions=True
+        )
+        self.main_tasks = []
+        self.auxiliary_tasks = []
+        self.tasks_supervisor_task = None
 
     async def wait(self):
-        if not self.process:
+        if not self.tasks_supervisor_task:
             raise RuntimeError("Streamer not started")
         return await self.tasks_supervisor_task
 
     async def stop(self, *, timeout: float):
+        if not self.tasks_supervisor_task:
+            raise RuntimeError("Streamer not started")
         self.stop_event.set()
         await asyncio.wait_for(self.tasks_supervisor_task, timeout)
-
-    async def _restart_process(self):
-        if not self.process:
-            raise RuntimeError("Process not started")
-
-        # Capture logs before stopping the process
-        restart_logs = self.process.get_recent_logs()
-        last_error = self.process.get_last_error()
-        # don't call the full start/stop methods since we only want to restart the process
-        await self.process.stop()
-
-        self.process = PipelineProcess.start(self.pipeline, self.params, self.request_id, self.stream_id)
-        self.status.inference_status.restart_count += 1
-        self.status.inference_status.last_restart_time = time.time()
-        self.status.inference_status.last_restart_logs = restart_logs
-        if last_error:
-            error_msg, error_time = last_error
-            self.status.inference_status.last_error = error_msg
-            self.status.inference_status.last_error_time = error_time
-
-        await self._emit_monitoring_event({
-            "type": "restart",
-            "pipeline": self.pipeline,
-            "restart_count": self.status.inference_status.restart_count,
-            "restart_time": self.status.inference_status.last_restart_time,
-            "restart_logs": restart_logs,
-            "last_error": last_error
-        })
-
-        logging.info(
-            f"PipelineProcess restarted. Restart count: {self.status.inference_status.restart_count}"
-        )
-
-    async def update_params(self, params: dict):
-        self.params = params
-        if self.process:
-            self.process.update_params(params)
-        self.status.update_params(params)
-
-        await self._emit_monitoring_event({
-            "type": "params_update",
-            "pipeline": self.pipeline,
-            "params": params,
-            "params_hash": self.status.inference_status.last_params_hash,
-            "update_time": self.status.inference_status.last_params_update_time
-        })
 
     async def report_status_loop(self):
         next_report = time.time() + status_report_interval
@@ -151,50 +122,8 @@ class PipelineStreamer:
                 await asyncio.sleep(next_report - current_time)
                 next_report += status_report_interval
 
-            event = self.get_status().model_dump()
+            event = self.process.get_status(clear_transient=True).model_dump()
             await self._emit_monitoring_event(event)
-
-            # Clear the large transient fields after reporting them once
-            self.status.inference_status.last_params = None
-            self.status.inference_status.last_restart_logs = None
-
-    def get_status(self) -> PipelineStatus:
-        new_state = self._current_state()
-        if new_state != self.status.state:
-            self.status.state = new_state
-            self.status.last_state_update_time = time.time()
-            logging.info(f"Pipeline state changed to {new_state}")
-        return self.status.model_copy()
-
-    def _current_state(self) -> str:
-        current_time = time.time()
-        input = self.status.input_status
-        last_input_time = input.last_input_time or 0
-        time_since_last_input = current_time - last_input_time
-        if time_since_last_input > 60:
-            if self.stop_event.is_set() and time_since_last_input < 90:
-                # give ourselves a 30s grace period to shutdown
-                logging.info(f"Detected DEGRADED_INPUT during shutdown: time_since_last_input={time_since_last_input:.1f}s")
-                return PipelineState.DEGRADED_INPUT
-            return PipelineState.OFFLINE
-        elif time_since_last_input > 2 or input.fps < 15:
-            logging.info(f"Detected DEGRADED_INPUT: time_since_last_input={time_since_last_input:.1f}s, fps={input.fps}")
-            return PipelineState.DEGRADED_INPUT
-
-        inference = self.status.inference_status
-        pipeline_load_time = max(self.status.start_time, inference.last_params_update_time or 0)
-        if not inference.last_output_time and current_time - pipeline_load_time < 30:
-            # 30s grace period for the pipeline to start
-            return PipelineState.ONLINE
-
-        delayed_frames = not inference.last_output_time or current_time - inference.last_output_time > 5
-        low_fps = inference.fps < min(10, 0.8 * input.fps)
-        recent_restart = inference.last_restart_time and current_time - inference.last_restart_time < 60
-        recent_error = inference.last_error_time and current_time - inference.last_error_time < 15
-        if delayed_frames or low_fps or recent_restart or recent_error:
-            return PipelineState.DEGRADED_INFERENCE
-
-        return PipelineState.ONLINE
 
     async def _emit_monitoring_event(self, event: dict):
         """Protected method to emit monitoring event with lock"""
@@ -206,66 +135,10 @@ class PipelineStreamer:
             except Exception as e:
                 logging.error(f"Failed to emit monitoring event: {e}")
 
-    async def monitor_loop(self):
-        while not self.stop_event.is_set():
-            await asyncio.sleep(1)
-            if not self.process or self.process.done.is_set():
-                continue
-
-            last_error = self.process.get_last_error()
-            if last_error:
-                error_msg, error_time = last_error
-                self.status.inference_status.last_error = error_msg
-                self.status.inference_status.last_error_time = error_time
-                await self._emit_monitoring_event({
-                    "type": "error",
-                    "pipeline": self.pipeline,
-                    "error": error_msg,
-                    "time": error_time
-                })
-
-            start_time = self.process.start_time
-            current_time = time.time()
-            last_input_time = max(self.status.input_status.last_input_time or 0, start_time)
-            last_output_time = max(self.status.inference_status.last_output_time or 0, start_time)
-            last_params_update_time = max(self.status.inference_status.last_params_update_time or 0, start_time)
-
-            time_since_last_input = current_time - last_input_time
-            time_since_last_output = current_time - last_output_time
-            time_since_start = current_time - start_time
-            time_since_last_params = current_time - last_params_update_time
-            time_since_reload = min(time_since_last_params, time_since_start)
-
-            if self.input_timeout > 0 and time_since_last_input > self.input_timeout:
-                logging.info(f"Input stream stopped for {time_since_last_input} seconds. Shutting down...")
-                self.stop_event.set()
-                return
-
-            gone_stale = (
-                time_since_last_output > time_since_last_input
-                and time_since_last_output > 60
-                and time_since_reload > 240
-            )
-            if time_since_last_input > 5 and not gone_stale:
-                # nothing to do if we're not sending inputs
-                continue
-
-            active_after_reload = time_since_last_output < (time_since_reload - 1)
-            stopped_recently = active_after_reload and time_since_last_output > 5 and time_since_last_output < 60
-            if stopped_recently or gone_stale:
-                logging.warning(
-                    "No output received while inputs are being sent. Restarting process."
-                )
-                await self._restart_process()
-
     async def run_ingress_loop(self):
         frame_count = 0
         start_time = 0.0
         async for av_frame in self.protocol.ingress_loop(self.stop_event):
-            if not self.process or self.process.done.is_set():
-                # no need to sleep since we want to consume input frames as fast as possible
-                continue
-
             if not start_time:
                 start_time = time.time()
 
@@ -295,23 +168,26 @@ class PipelineStreamer:
                     square_size = min(width, height)
                     start_x = width // 2 - square_size // 2
                     start_y = height // 2 - square_size // 2
-                    frame_array = frame_array[start_y:start_y+square_size, start_x:start_x+square_size]
+                    frame_array = frame_array[
+                        start_y : start_y + square_size, start_x : start_x + square_size
+                    ]
 
                 # Resize using cv2 (much faster than PIL)
                 frame_array = cv2.resize(frame_array, (512, 512))
                 frame = Image.fromarray(frame_array)
 
-            logging.debug(f"Sending input frame. Scaled from {width}x{height} to {frame.size[0]}x{frame.size[1]}")
+            logging.debug(
+                f"Sending input frame. Scaled from {width}x{height} to {frame.size[0]}x{frame.size[1]}"
+            )
             av_frame = av_frame.replace_image(frame)
             self.process.send_input(av_frame)
-            self.status.input_status.last_input_time = time.time()  # Track time after send completes
 
             # Increment frame count and measure FPS
             frame_count += 1
             elapsed_time = time.time() - start_time
             if elapsed_time >= fps_log_interval:
-                self.status.input_status.fps = frame_count / elapsed_time
-                logging.info(f"Input FPS: {self.status.input_status.fps:.2f}")
+                status = self.process.get_status()
+                logging.info(f"Input FPS: {status.input_status.fps:.2f}")
                 frame_count = 0
                 start_time = time.time()
         logging.info("Ingress loop ended")
@@ -321,10 +197,6 @@ class PipelineStreamer:
             frame_count = 0
             start_time = 0.0
             while not self.stop_event.is_set():
-                if not self.process or self.process.done.is_set():
-                    await asyncio.sleep(0.05)
-                    continue
-
                 output_frame = await self.process.recv_output()
                 if not output_frame:
                     continue
@@ -335,7 +207,9 @@ class PipelineStreamer:
                     continue
 
                 if not isinstance(output_frame, VideoOutput):
-                    logging.warning(f"Unknown output frame type {type(output_frame)}, dropping")
+                    logging.warning(
+                        f"Unknown output frame type {type(output_frame)}, dropping"
+                    )
                     continue
 
                 output_image = output_frame.frame.image
@@ -344,7 +218,6 @@ class PipelineStreamer:
                     # only start measuring output FPS after the first frame
                     start_time = time.time()
 
-                self.status.inference_status.last_output_time = time.time()  # Track time after receive completes
                 logging.debug(
                     f"Output image received out_width: {output_image.width}, out_height: {output_image.height}"
                 )
@@ -355,8 +228,8 @@ class PipelineStreamer:
                 frame_count += 1
                 elapsed_time = time.time() - start_time
                 if elapsed_time >= fps_log_interval:
-                    self.status.inference_status.fps = frame_count / elapsed_time
-                    logging.info(f"Output FPS: {self.status.inference_status.fps:.2f}")
+                    status = self.process.get_status()
+                    logging.info(f"Output FPS: {status.inference_status.fps:.2f}")
                     frame_count = 0
                     start_time = time.time()
 
@@ -367,7 +240,7 @@ class PipelineStreamer:
         """Consumes control messages from the protocol and updates parameters"""
         async for params in self.protocol.control_loop(self.stop_event):
             try:
-                await self.update_params(params)
+                await self.process.update_params(params)
             except Exception as e:
                 logging.error(f"Error updating model with control message: {e}")
         logging.info("Control loop ended")

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -54,8 +54,8 @@ class LiveVideoToVideoPipeline(Pipeline):
                             "control_url": control_url,
                             "events_url": events_url,
                             "params": params,
-                            "request_id": request_id,
-                            "stream_id": stream_id,
+                            "request_id": request_id or "",
+                            "stream_id": stream_id or "",
                         }
                     ),
                     headers={"Content-Type": "application/json"},

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -42,6 +42,8 @@ class LiveVideoToVideoPipeline(Pipeline):
         max_retries = 10
         thrown_ex = None
         for attempt in range(max_retries):
+            if attempt > 0:
+                time.sleep(1)
             try:
                 conn = http.client.HTTPConnection("localhost", 8888)
                 conn.request(
@@ -62,15 +64,13 @@ class LiveVideoToVideoPipeline(Pipeline):
                 )
                 response = conn.getresponse()
                 if response.status != 200:
-                    time.sleep(1)
                     continue
 
                 logging.info("Stream started successfully")
-                break  # Break out of the retry loop on success
+                return {} # Return an empty success response
             except Exception as e:
                 thrown_ex = e
                 logging.error(f"Attempt {attempt + 1} failed", exc_info=True)
-                time.sleep(1)
 
         raise InferenceError(original_exception=thrown_ex)
 

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -62,6 +62,7 @@ class LiveVideoToVideoPipeline(Pipeline):
                 )
                 response = conn.getresponse()
                 if response.status != 200:
+                    time.sleep(1)
                     continue
 
                 logging.info("Stream started successfully")


### PR DESCRIPTION
We want to improve cold start time for a stream so can't afford the isolation of
having one process per stream. Restructure infer.py so it is started with the
whole container and re-used across streams.

This was accomplished by removing the process-managemenet logic from the Streamer
and moving to an outer process guardian, then only create ephemeral streamers that use
the process guardian. 

The infer.py now exposes an API to be called to start the streamer as well which is
called from the runner API. The process is started immediately with the runner API
startup (from pipeline creation).