### PR TITLE
streamer: add logging to debug control api failures

### DIFF
--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -134,15 +134,20 @@ class PipelineProcess:
                 while not self.param_update_queue.empty():
                     params = self.param_update_queue.get_nowait()
                     try:
-                        if params.request_id and params.stream_id:
+                        logging.info(f"PipelineProcess: Processing parameter update from queue: {params}")
+                        if isinstance(params, dict) and "request_id" in params and "stream_id" in params:
+                            logging.info(f"PipelineProcess: Resetting logging fields with request_id={params['request_id']}, stream_id={params['stream_id']}")
                             self._reset_logging_fields(
-                                params.request_id, params.stream_id
+                                params["request_id"], params["stream_id"]
                             )
                         else:
+                            logging.info(f"PipelineProcess: Updating pipeline parameters")
                             pipeline.update_params(**params)
-                        logging.info(f"Updated params: {params}")
+                            logging.info(f"PipelineProcess: Successfully applied params to pipeline: {params}")
                     except Exception as e:
-                        report_error(f"Error updating params: {e}")
+                        error_msg = f"Error updating params: {str(e)}"
+                        logging.error(error_msg, exc_info=True)
+                        report_error(error_msg)
 
                 try:
                     input_frame = self.input_queue.get(timeout=0.1)

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -91,6 +91,7 @@ class ProcessGuardian:
         if not self.process:
             raise RuntimeError("Process not running")
         self.params = params
+        logging.info(f"ProcessGuardian: Queuing parameter update with hash={self.status.inference_status.last_params_hash}, params={params}")
         self.process.update_params(params)
         self.status.update_params(params)
 
@@ -103,6 +104,7 @@ class ProcessGuardian:
                 "update_time": self.status.inference_status.last_params_update_time,
             }
         )
+        logging.info(f"ProcessGuardian: Parameter update queued and monitoring callback completed. Hash={self.status.inference_status.last_params_hash}")
 
     def get_status(self, clear_transient: bool = False) -> PipelineStatus:
         new_state = self._current_state()


### PR DESCRIPTION
It's difficult to trace why control api is failing in staging. Add a few logs to make it easier to debug. 