### PR TITLE
Update onnxruntime gpu and mediapipe

### DIFF
--- a/runner/docker/Dockerfile.live-app__PIPELINE__
+++ b/runner/docker/Dockerfile.live-app__PIPELINE__
@@ -11,10 +11,13 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install any additional Python packages
+
 COPY requirements.live-ai.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 # TODO: Figure out a way to have this in requirements file
 RUN pip install --no-cache-dir triton==3.1.0
+RUN pip uninstall -y onnx onnxruntime onnxruntime-gpu
+RUN pip install onnx==1.17.0 onnxruntime-gpu==1.17.0
 
 # Set environment variables
 ENV MAX_WORKERS=1

--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -26,3 +26,4 @@ aiohttp==3.10.9
 nvidia-ml-py==12.560.30
 pynvml==12.0.0
 prometheus_client>=0.21.1
+mediapipe==0.10.20


### PR DESCRIPTION
Uninstalls onnxruntime ( non-gpu ) and installs matching versions of onnx and onnxruntime-gpu to fix ( root of 5FPS issue ):

```
DWPose: Onnxruntime not found or doesn't come with acceleration providers, switch to OpenCV with CPU device. DWPose might run very slowly
```

Also updates mediapipe 0.10.8 --> 0.10.20 ( this should probably be pushed down to comfystream req's - PR to follow )
Eliminates error:
```
E0000 00:00:1741115465.623114    1243 gl_context.cc:408] INTERNAL: ; RET_CHECK failure (mediapipe/gpu/gl_context_egl.cc:303) successeglMakeCurrent() returned error 0x3008;  (entering GL context)
```