### PR TITLE
Add request ID fields to request and response body schemas

### DIFF
--- a/runner/app/live/log.py
+++ b/runner/app/live/log.py
@@ -30,7 +30,7 @@ def config_logging(*, log_level: int = 0, request_id: str = "", stream_id: str =
 
 def config_logging_fields(handler: logging.Handler, request_id: str, stream_id: str):
     formatter = logging.Formatter(
-        "timestamp=%(asctime)s level=%(levelname)s location=%(filename)s:%(lineno)d:%(funcName)s request_id=%(request_id)s stream_id=%(stream_id)s message=%(message)s",
+        "timestamp=%(asctime)s level=%(levelname)s location=%(filename)s:%(lineno)d:%(funcName)s gateway_request_id=%(request_id)s stream_id=%(stream_id)s message=%(message)s",
         defaults={"request_id": request_id, "stream_id": stream_id},
         datefmt="%Y-%m-%d %H:%M:%S",
     )

--- a/runner/app/routes/live_video_to_video.py
+++ b/runner/app/routes/live_video_to_video.py
@@ -144,6 +144,11 @@ async def live_video_to_video(
         )
 
     try:
+        if requestID is None:
+            requestID = params.gateway_request_id
+        if streamID is None:
+            streamID = params.stream_id
+        logger.error(f"AAA live_video_to_video: {requestID} {streamID}")
         pipeline(**params.model_dump(), request_id=requestID, stream_id=streamID)
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):

--- a/runner/app/routes/live_video_to_video.py
+++ b/runner/app/routes/live_video_to_video.py
@@ -72,6 +72,20 @@ class LiveVideoToVideoParams(BaseModel):
             description="Initial parameters for the pipeline."
         ),
     ]
+    gateway_request_id: Annotated[
+        str,
+        Field(
+            default="",
+            description=" The ID of the Gateway request (for logging purposes)."
+        ),
+    ]
+    stream_id: Annotated[
+        str,
+        Field(
+            default="",
+            description="The Stream ID (for logging purposes)."
+        ),
+    ]
 
 RESPONSES: dict[int | str, dict[str, Any]]= {
     status.HTTP_200_OK: {

--- a/runner/app/routes/live_video_to_video.py
+++ b/runner/app/routes/live_video_to_video.py
@@ -76,7 +76,7 @@ class LiveVideoToVideoParams(BaseModel):
         str,
         Field(
             default="",
-            description=" The ID of the Gateway request (for logging purposes)."
+            description="The ID of the Gateway request (for logging purposes)."
         ),
     ]
     stream_id: Annotated[
@@ -148,7 +148,6 @@ async def live_video_to_video(
             requestID = params.gateway_request_id
         if streamID is None:
             streamID = params.stream_id
-        logger.error(f"AAA live_video_to_video: {requestID} {streamID}")
         pipeline(**params.model_dump(), request_id=requestID, stream_id=streamID)
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):

--- a/runner/app/routes/utils.py
+++ b/runner/app/routes/utils.py
@@ -145,6 +145,10 @@ class LiveVideoToVideoResponse(BaseModel):
         default='',
         description="URL for subscribing to events for pipeline status and logs",
     )
+    request_id: str = Field(
+        default='',
+        description="The ID generated for this request",
+    )
 
 
 class APIError(BaseModel):

--- a/runner/gateway.openapi.yaml
+++ b/runner/gateway.openapi.yaml
@@ -1027,6 +1027,16 @@ components:
           title: Params
           description: Initial parameters for the pipeline.
           default: {}
+        gateway_request_id:
+          type: string
+          title: Gateway Request Id
+          description: ' The ID of the Gateway request (for logging purposes).'
+          default: ''
+        stream_id:
+          type: string
+          title: Stream Id
+          description: The Stream ID (for logging purposes).
+          default: ''
       type: object
       required:
       - subscribe_url
@@ -1052,6 +1062,11 @@ components:
           type: string
           title: Events Url
           description: URL for subscribing to events for pipeline status and logs
+          default: ''
+        request_id:
+          type: string
+          title: Request Id
+          description: The ID generated for this request
           default: ''
       type: object
       required:

--- a/runner/gateway.openapi.yaml
+++ b/runner/gateway.openapi.yaml
@@ -1030,7 +1030,7 @@ components:
         gateway_request_id:
           type: string
           title: Gateway Request Id
-          description: ' The ID of the Gateway request (for logging purposes).'
+          description: The ID of the Gateway request (for logging purposes).
           default: ''
         stream_id:
           type: string

--- a/runner/openapi.yaml
+++ b/runner/openapi.yaml
@@ -1173,6 +1173,14 @@ components:
           title: Params
           description: Initial parameters for the pipeline.
           default: {}
+        gateway_request_id:
+          type: string
+          title: Gateway Request ID
+          description: The ID of the Gateway request (for logging purposes).
+        stream_id:
+          type: string
+          title: Stream ID
+          description: The Stream ID (for logging purposes).
       type: object
       required:
       - subscribe_url
@@ -1198,6 +1206,10 @@ components:
           title: Events Url
           description: URL for subscribing to events for pipeline status and logs
           default: ''
+        request_id:
+          type: string
+          title: Request ID
+          description: The ID generated for this request.
       type: object
       required:
       - subscribe_url

--- a/runner/openapi.yaml
+++ b/runner/openapi.yaml
@@ -1175,12 +1175,14 @@ components:
           default: {}
         gateway_request_id:
           type: string
-          title: Gateway Request ID
+          title: Gateway Request Id
           description: The ID of the Gateway request (for logging purposes).
+          default: ''
         stream_id:
           type: string
-          title: Stream ID
+          title: Stream Id
           description: The Stream ID (for logging purposes).
+          default: ''
       type: object
       required:
       - subscribe_url
@@ -1208,8 +1210,9 @@ components:
           default: ''
         request_id:
           type: string
-          title: Request ID
-          description: The ID generated for this request.
+          title: Request Id
+          description: The ID generated for this request
+          default: ''
       type: object
       required:
       - subscribe_url


### PR DESCRIPTION
This is a dependency for https://github.com/livepeer/go-livepeer/pull/3408 We want explicit fields in the request and response bodies for requestIDs.

This change also means the runner accepts the IDs in the request body as well as headers, so we can switch the caller over to use the request body and then remove the headers.