### PR TITLE
create cliptext model directory

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -97,6 +97,8 @@ function download_live_models() {
     echo "ERROR: ComfyUI base image $AI_RUNNER_COMFYUI_IMAGE not found"
     return 1
   fi
+  # comfystream setup_models.py should ultimately handle these missing nested directories
+  mkdir -p ./models/text_encoders/CLIPText
   # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
   docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
   docker run --rm -v ./models:/models --gpus all -l ComfyUI-Setup-Models $AI_RUNNER_COMFYUI_IMAGE \


### PR DESCRIPTION
comfystream setup_models.py should ultimately handle these missing nested directories, but this should unbreak staging