### PR TITLE
Fix setting streamID

### DIFF
--- a/runner/app/routes/live_video_to_video.py
+++ b/runner/app/routes/live_video_to_video.py
@@ -146,6 +146,8 @@ async def live_video_to_video(
     try:
         if requestID is None:
             requestID = params.gateway_request_id
+        if streamID is not None and params.stream_id == "":
+            params.stream_id = streamID
         pipeline(**params.model_dump(), request_id=requestID)
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):


### PR DESCRIPTION
Previous attempt was causing the `multiple values` comfyui error, this is to fix that and add streamID back into the logs.