### PR TITLE
Set logging level for comfy package to WARN

### DIFF
--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -267,7 +267,7 @@ class ComfyUI(Pipeline):
         super().__init__(**params)
 
         comfy_ui_workspace = os.getenv(COMFY_UI_WORKSPACE_ENV)
-        self.client = ComfyStreamClient(cwd=comfy_ui_workspace)
+        self.client = ComfyStreamClient(cwd=comfy_ui_workspace, verbose="WARNING")
         self.params: ComfyUIParams
 
         self.update_params(**params)

--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -267,7 +267,7 @@ class ComfyUI(Pipeline):
         super().__init__(**params)
 
         comfy_ui_workspace = os.getenv(COMFY_UI_WORKSPACE_ENV)
-        self.client = ComfyStreamClient(cwd=comfy_ui_workspace, verbose="WARNING")
+        self.client = ComfyStreamClient(cwd=comfy_ui_workspace)
         self.params: ComfyUIParams
 
         self.update_params(**params)

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -111,6 +111,12 @@ class PipelineProcess:
         if torch.cuda.is_available():
             os.environ["CUDA_VISIBLE_DEVICES"] = str(torch.cuda.current_device())
 
+        # ComfystreamClient/embeddedComfyClient is not respecting config parameters
+        # such as verbose='WARNING', logging_level='WARNING'
+        # Setting here to override and supress excessive INFO logging 
+        # ( load_gpu_models is calling logging.info() for every frame )
+        logging.getLogger("comfy").setLevel(logging.WARNING)
+
         def report_error(error_msg: str):
             error_event = {
                 "message": error_msg,


### PR DESCRIPTION
Excessive 'INFO' logging may be slowing down pipelines.

This sets the log level to WARNING for the `comfy` package in the pipeline process and removes logs such as:
```
timestamp=2025-03-07 21:30:14 level=INFO location=model_management.py:629:_load_models_gpu gateway_request_id=8d6efc9d stream_id= message=Loaded <LoadedModel <ModelPatcher for BaseModel (model_dtype=torch.float16 device=cuda:0 size=7.8 KiB operations=disable_weight_init)>>
```

Attempts to use config arguments to ComfystreamClient did not produce the same results:
runner/app/live/pipelines/comfyui.py:270
```
        self.client = ComfyStreamClient(cwd=comfy_ui_workspace, verbose='WARNING', logging_level='WARNING')
```
had no effect.