### PR TITLE
Change the error message key to match the gateway

### DIFF
--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -211,7 +211,7 @@ class ProcessGuardian:
                         {
                             "type": "error",
                             "pipeline": self.pipeline,
-                            "error": error_msg,
+                            "message": error_msg,
                             "time": error_time,
                         }
                     )


### PR DESCRIPTION
This is so that we can match the [gateway](https://github.com/livepeer/go-livepeer/blob/fa50112c23bbe4e8243380245e13f68bfc28b311/server/ai_live_video.go#L375) and then be able to aggregate on error types in our monitoring