### PR TITLE
trickle: Retry encoder if necessary

### DIFF
--- a/runner/app/live/streamer/protocol/last_value_cache.py
+++ b/runner/app/live/streamer/protocol/last_value_cache.py
@@ -1,0 +1,46 @@
+import threading
+from typing import Optional, TypeVar, Generic, Callable
+
+T = TypeVar('T')
+
+class LastValueCache(Generic[T]):
+    """
+    A thread-safe cache that stores the last value produced.
+    Consumers can wait for a value to be available with a timeout.
+    """
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._UNSET = object()
+        self._value = self._UNSET
+
+    def put(self, value: T) -> None:
+        """Store a new value and notify all waiting consumers."""
+        with self._lock:
+            self._value = value
+            self._condition.notify_all()
+
+    def get(self, timeout: float = 30.0) -> Optional[T]:
+        """
+        Get the latest value, waiting if necessary.
+
+        Args:
+            timeout: Maximum time to wait in seconds
+
+        Returns:
+            The latest value, or None if timeout occurs before a value is available
+        """
+        def value_is_set():
+            return self._value is not self._UNSET
+
+        with self._condition:
+            # Wait for a value to be available
+            if not value_is_set():
+                success = self._condition.wait_for(value_is_set, timeout=timeout)
+                if not success:
+                    logging.warning(f"Timed out waiting for value (timeout={timeout}s)")
+                    return None
+
+            return self._value
+
+

--- a/runner/app/live/trickle/encoder.py
+++ b/runner/app/live/trickle/encoder.py
@@ -36,7 +36,7 @@ def encode_av(
         read_fd, write_fd = os.pipe()
         read_file  = os.fdopen(read_fd,  'rb', buffering=0)
         write_file = os.fdopen(write_fd, 'wb', buffering=0)
-        output_callback(read_file, url)
+        output_callback(read_file, write_file, url)
         return write_file
 
     # Open the output container in write mode
@@ -138,12 +138,12 @@ def rescale_ts(pts: int, orig_tb: Fraction, dest_tb: Fraction):
 
 def log_frame_timestamps(frame_type: str, frame: InputFrame):
     ts = frame.log_timestamps
-    
+
     def log_duration(start_key: str, end_key: str):
         if start_key in ts and end_key in ts:
             duration = ts[end_key] - ts[start_key]
             logging.debug(f"frame_type={frame_type} start_tag={start_key} end_tag={end_key} duration_s={duration}s")
-    
+
     log_duration('frame_init', 'pre_process_frame')
     log_duration('pre_process_frame', 'post_process_frame')
     log_duration('post_process_frame', 'frame_end')

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -11,6 +11,9 @@ from .trickle_publisher import TricklePublisher
 from .decoder import decode_av
 from .encoder import encode_av
 
+MAX_ENCODER_RETRIES = 3
+ENCODER_RETRY_RESET_SECONDS = 300  # 5 minutes in seconds
+
 async def run_subscribe(subscribe_url: str, image_callback, put_metadata, monitoring_callback):
     # TODO add some pre-processing parameters, eg image size
     try:
@@ -81,6 +84,38 @@ async def decode_in(in_pipe, frame_callback, put_metadata):
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, decode_runner)
 
+def encode_in(task_pipes, task_lock, image_generator, sync_callback, get_metadata, **kwargs):
+    # encode_av has a tendency to crash, so restart as necessary
+    retryCount = 0
+    last_retry_time = time.time()
+    while retryCount < MAX_ENCODER_RETRIES:
+        try:
+            encode_av(image_generator, sync_callback, get_metadata, **kwargs)
+            break  # clean exit
+        except Exception as exc:
+            current_time = time.time()
+            # Reset retry counter if enough time has elapsed
+            if current_time - last_retry_time > ENCODER_RETRY_RESET_SECONDS:
+                logging.info("Resetting encoder retry count")
+                retryCount = 0
+            retryCount += 1
+            last_retry_time = current_time
+            if retryCount < MAX_ENCODER_RETRIES:
+                logging.error(f"Error in encode_av, retrying {retryCount}/{MAX_ENCODER_RETRIES}: {exc}")
+            else:
+                logging.error(f"Error in encode_av, maximum retries reached: {exc}")
+            # close leftover writer ends of any pipes to prevent hanging
+            pipe_count = 0
+            with task_lock:
+                pipes = list(task_pipes)
+                for p in pipes:
+                    try:
+                        p.close()
+                        pipe_count += 1
+                    except Exception as e:
+                        logging.error(f"Error closing pipe on task list: {e}")
+            logging.info(f"Closed pipes - {pipe_count}")
+
 async def run_publish(publish_url: str, image_generator, get_metadata, monitoring_callback):
     first_segment = True
 
@@ -111,30 +146,36 @@ async def run_publish(publish_url: str, image_generator, get_metadata, monitorin
                         }, queue_event_type="stream_trace")
                 transport.close()
 
-        def sync_callback(pipe_file, pipe_name):
+        def sync_callback(pipe_reader, pipe_writer, pipe_name):
             def do_schedule():
-                schedule_callback(callback(pipe_file, pipe_name), pipe_name)
+                schedule_callback(callback(pipe_reader, pipe_name), pipe_writer, pipe_name)
             loop.call_soon_threadsafe(do_schedule)
 
         # hold tasks since `loop.create_task` is a weak reference that gets GC'd
         # TODO use asyncio.TaskGroup once all pipelines are on Python 3.11+
+        # Also hold pipes in case we need to explicitly close them during exceptions
         live_tasks = set()
+        live_pipes = set()
         live_tasks_lock = threading.Lock()
 
-        def schedule_callback(coro, pipe_name):
+        def schedule_callback(coro, pipe_writer, pipe_name):
             task = loop.create_task(coro)
             with live_tasks_lock:
                 live_tasks.add(task)
-            def task_done(t: asyncio.Task):
+                live_pipes.add(pipe_writer)
+            def task_done2(t: asyncio.Task, p):
                 try:
                     t.result()
                 except Exception as e:
                     logging.error(f"Task {pipe_name} crashed: {e}")
                 with live_tasks_lock:
                     live_tasks.remove(t)
+                    live_pipes.remove(p)
+            def task_done(t2:asyncio.Task):
+                return task_done2(task, pipe_writer)
             task.add_done_callback(task_done)
 
-        encode_thread = threading.Thread(target=encode_av, args=(image_generator, sync_callback, get_metadata), kwargs={"audio_codec":"libopus"})
+        encode_thread = threading.Thread(target=encode_in, args=(live_pipes, live_tasks_lock, image_generator, sync_callback, get_metadata), kwargs={"audio_codec":"libopus"})
         encode_thread.start()
         logging.debug("run_publish: encoder thread started")
 

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -106,15 +106,17 @@ def encode_in(task_pipes, task_lock, image_generator, sync_callback, get_metadat
                 logging.exception("Error in encode_av, maximum retries reached", stack_info=True)
             # close leftover writer ends of any pipes to prevent hanging
             pipe_count = 0
+            total_pipes = 0
             with task_lock:
                 pipes = list(task_pipes)
+                total_pipes = len(pipes)
                 for p in pipes:
                     try:
                         p.close()
                         pipe_count += 1
                     except Exception as e:
                         logging.exception("Error closing pipe on task list", stack_info=True)
-            logging.info(f"Closed pipes - {pipe_count}")
+            logging.info(f"Closed pipes - {pipe_count}/{total_pipes}")
 
 async def run_publish(publish_url: str, image_generator, get_metadata, monitoring_callback):
     first_segment = True


### PR DESCRIPTION
This requires adding a last value cache for the media metadata rather than pulling the metadata from a queue, because the queue may be empty when the encoder restarts.

We also need to explicitly close the write end of any pipes that may be dangling after the exception, since pyav will no longer be closing those.