### PR TITLE
upgrade build-push-action to v6 to enable build summaries

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -67,7 +67,7 @@ jobs:
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 
       - name: Build and push runner docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:runner"
           platforms: linux/amd64

--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [self-hosted, linux, amd64]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
           ref: ${{ github.event.pull_request.head.sha }}
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
 
       - name: Build and push live-base image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         if: steps.check_build.outputs.should_build == 'true'
         with:
           context: "{{defaultContext}}:runner"
@@ -86,7 +86,7 @@ jobs:
         pipeline: [comfyui]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
           ref: ${{ github.event.pull_request.head.sha }}
@@ -109,7 +109,7 @@ jobs:
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
 
       - name: Build and push pipeline base image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         if: |
           github.event_name == 'workflow_dispatch' ||
           github.event_name == 'push' ||
@@ -144,7 +144,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}},prefix=live-app-${{ matrix.pipeline }}-
 
       - name: Build and push pipeline app image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:runner"
           platforms: linux/amd64
@@ -165,7 +165,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
           ref: ${{ github.event.pull_request.head.sha }}
@@ -216,7 +216,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}},prefix=live-app-noop-
 
       - name: Build and push noop image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         if: steps.check_build.outputs.should_build == 'true'
         with:
           context: "{{defaultContext}}:runner"

--- a/.github/workflows/ai-runner-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-pipelines-docker.yaml
@@ -37,7 +37,7 @@ jobs:
           - docker/Dockerfile.llm
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -84,7 +84,7 @@ jobs:
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }},prefix=${{ steps.docker-tag.outputs.suffix }}-
 
       - name: Build and push runner docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:runner"
           platforms: linux/amd64


### PR DESCRIPTION
`build-push-action@v6` enables build summaries - https://docs.docker.com/build/ci/github-actions/build-summary/