### PR TITLE
live/trickle: Send first segment event after it's read

### DIFF
--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -39,18 +39,18 @@ async def subscribe(subscribe_url, out_pipe, monitoring_callback):
                 segment = await subscriber.next()
                 if not segment:
                     break # complete
-                if first_segment:
-                    first_segment = False
-                    await monitoring_callback({
-                        "type": "runner_receive_first_ingest_segment",
-                        "timestamp": int(time.time() * 1000)
-                    }, queue_event_type="stream_trace")
                 while True:
                     chunk = await segment.read()
                     if not chunk:
                         break # end of segment
                     out_pipe.write(chunk)
                     await out_pipe.drain()
+                if first_segment:
+                    first_segment = False
+                    await monitoring_callback({
+                        "type": "runner_receive_first_ingest_segment",
+                        "timestamp": int(time.time() * 1000)
+                    }, queue_event_type="stream_trace")
             except aiohttp.ClientError as e:
                 logging.info(f"Failed to read segment - {e}")
                 break # end of stream?


### PR DESCRIPTION
To be consistent with the other events in the platform we should send it after the
segment has been fully read, not on the "first byte". This inconsistency was making
the comparison with other events impossible and it looked like runner got the event
before the gateway itself sent it.