### PR TITLE
workflows: Fix docker build cache being overwritten across repo

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -39,12 +39,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -66,17 +60,24 @@ jobs:
             type=raw,value=${{ github.event.pull_request.head.ref }}
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
       - name: Build and push runner docker image
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:runner"
+          file: "Dockerfile"
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          file: "Dockerfile"
+          annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=livepeerci/build:cache
-          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+          cache-from: type=registry,ref=livepeer/ai-runner:dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:dockerbuildcache,mode=max
 
       - name: Notify new build upload
         run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -71,8 +71,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: livepeer/ai-runner:live-base
           file: docker/Dockerfile.live-base
-          cache-from: type=registry,ref=livepeerci/build:cache
-          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+          cache-from: type=registry,ref=livepeer/ai-runner:live-base-dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:live-base-dockerbuildcache,mode=max
 
   build-pipeline-images:
     name: Build pipeline images
@@ -128,8 +128,8 @@ jobs:
           file: docker/Dockerfile.live-base-${{ matrix.pipeline }}
           build-args: |
             PIPELINE=${{ matrix.pipeline }}
-          cache-from: type=registry,ref=livepeerci/build:cache
-          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+          cache-from: type=registry,ref=livepeer/ai-runner:live-base-${{ matrix.pipeline }}-dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:live-base-${{ matrix.pipeline }}-dockerbuildcache,mode=max
 
       - name: Extract metadata for app image
         id: meta
@@ -147,15 +147,17 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:runner"
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
           file: docker/Dockerfile.live-app__PIPELINE__
           build-args: |
             PIPELINE=${{ matrix.pipeline }}
             GIT_SHA=${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}
-          cache-from: type=registry,ref=livepeerci/build:cache
-          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=livepeer/ai-runner:live-app-${{ matrix.pipeline }}-dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:live-app-${{ matrix.pipeline }}-dockerbuildcache,mode=max
 
   build-noop:
     name: Build pipeline image (noop)
@@ -220,9 +222,11 @@ jobs:
         if: steps.check_build.outputs.should_build == 'true'
         with:
           context: "{{defaultContext}}:runner"
+          file: docker/Dockerfile.live-app-noop
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          file: docker/Dockerfile.live-app-noop
-          cache-from: type=registry,ref=livepeerci/build:cache
-          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=livepeer/ai-runner:live-app-noop-dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:live-app-noop-dockerbuildcache,mode=max


### PR DESCRIPTION
we kept using the same build cache layer for go-livepeer and all ai-runner pipeline docker images (base/app/noop). this led to all docker builds being able to utilise 0% of cache as it kept getting overwritten.