### PR TITLE
Revert "Fix delayed teardowns"

### DIFF
--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -55,10 +55,10 @@ class PipelineStreamer:
             run_in_background("ingress_loop", self.run_ingress_loop()),
             run_in_background("egress_loop", self.run_egress_loop()),
             run_in_background("report_status_loop", self.report_status_loop()),
-            run_in_background("control_loop", self.run_control_loop()),
         ]
         # auxiliary tasks that are not critical to the supervisor, but which we want to run
         self.auxiliary_tasks = [
+            run_in_background("control_loop", self.run_control_loop())
         ]
         self.tasks_supervisor_task = run_in_background(
             "tasks_supervisor", self.tasks_supervisor()


### PR DESCRIPTION
Reverts livepeer/ai-runner#441

This didn't solve the issue. control_loop is not a compulsory loop.