### PR TITLE
lv2v: Omit misleading healthcheck stacktrace

### DIFF
--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -97,7 +97,7 @@ class LiveVideoToVideoPipeline(Pipeline):
                 status="IDLE" if pipe_status.state == "OFFLINE" else "OK"
             )
         except Exception as e:
-            logging.error(f"Failed to get status", exc_info=True)
+            logging.error(f"Failed to get status: {type(e).__name__}: {str(e)}")
             raise ConnectionError(f"Failed to get status: {e}")
 
     def start_process(self, **kwargs):

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -97,7 +97,7 @@ class LiveVideoToVideoPipeline(Pipeline):
                 status="IDLE" if pipe_status.state == "OFFLINE" else "OK"
             )
         except Exception as e:
-            logging.error(f"Failed to get status: {type(e).__name__}: {str(e)}")
+            logging.error(f"[HEALTHCHECK] Failed to get status: {type(e).__name__}: {str(e)}")
             raise ConnectionError(f"Failed to get status: {e}")
 
     def start_process(self, **kwargs):


### PR DESCRIPTION
It has been misleading investigations to include the stack trace of the health check failure, since it looks like there is where the problem is on the code. Since the exceptions we get here are generally just problems with the healthcheck itself like the server being down or hanging, we better just log the error message.