### PR TITLE
main: Configure logging level based on env

### DIFF
--- a/runner/app/main.py
+++ b/runner/app/main.py
@@ -10,7 +10,7 @@ from app.live.log import config_logging
 from prometheus_client import Gauge, generate_latest, CONTENT_TYPE_LATEST
 from starlette.responses import Response
 
-config_logging()
+config_logging(log_level=logging.DEBUG if os.getenv("VERBOSE_LOGGING")=="1" else logging.INFO)
 logger = logging.getLogger(__name__)
 
 VERSION = Gauge('version', 'Runner version', ['app', 'version'])


### PR DESCRIPTION
We were leaving the log_level to the default, which for some reason meant we were only logging ERROR level onwards (even tho python docs say it would log everything).

I didn't spend too much time understanding why that was the case, but configuring the logs like this fixes the issue and we get all INFO logs (or DEBUG if verbose is set). So we'll be in a better place to debug the infer.py crashes.