### PR TITLE
lv2v: Log process diagnostics periodically

### DIFF
--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -233,7 +233,7 @@ class LiveVideoToVideoPipeline(Pipeline):
 
         # Collect /proc information
         os_proc_info = {}
-        for proc_file in ["status", "wchan", "io", "stack", "limits", "maps"]:
+        for proc_file in ["status", "wchan", "io"]:
             try:
                 path = f"/proc/{pid}/{proc_file}"
                 if os.path.exists(path):

--- a/runner/requirements.txt
+++ b/runner/requirements.txt
@@ -19,6 +19,7 @@ sentencepiece== 0.2.0
 protobuf==5.27.2
 bitsandbytes==0.43.3
 psutil==6.0.0
+types-psutil==6.0.0.20241011
 PyYAML==6.0.2
 nvidia-ml-py==12.560.30
 pynvml==12.0.0


### PR DESCRIPTION
This is to add further monitoring to the infer.py process by periodically logging
information about the process collected from the OS. We also log such information
when we realize that the process exited or when the healthcheck failed with an
exception (not when it fails with a normal HTTP response, which means the process
is fine).