### PR TITLE
lv2v/infer.py: Set uncaught exception handlers to terminate process

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -6,8 +6,8 @@ import signal
 import sys
 import os
 import traceback
+import threading
 from typing import List
-import logging
 
 from streamer import PipelineStreamer, ProcessGuardian
 
@@ -19,6 +19,34 @@ from api import start_http_server
 from log import config_logging, log_timing
 from streamer.protocol.trickle import TrickleProtocol
 from streamer.protocol.zeromq import ZeroMQProtocol
+
+
+def asyncio_exception_handler(loop, context):
+    """
+    Handles unhandled exceptions in asyncio tasks, logging the error and terminating the application.
+    """
+    exception = context.get('exception')
+    logging.error(f"Caught unhandled exception in asyncio task: {exception}")
+    if exception:
+        logging.error(f"Traceback:\n{''.join(traceback.format_tb(exception.__traceback__))}")
+
+    logging.error("Terminating due to unhandled exception in asyncio task")
+    os._exit(1)
+
+
+def thread_exception_hook(original_hook):
+    """
+    Creates a custom exception hook for threads that logs the error and terminates the application.
+    """
+    def custom_hook(args):
+        logging.error(f"Caught unhandled exception in thread {args.thread}: {args.exc_value}")
+        logging.error(f"Traceback:\n{''.join(traceback.format_tb(args.exc_traceback))}")
+
+        original_hook(args)
+
+        logging.error("Terminating due to unhandled exception in thread")
+        os._exit(1)
+    return custom_hook
 
 
 async def main(
@@ -35,6 +63,9 @@ async def main(
     request_id: str,
     stream_id: str,
 ):
+    loop = asyncio.get_event_loop()
+    loop.set_exception_handler(asyncio_exception_handler)
+
     process = ProcessGuardian(pipeline, params or {})
     # Only initialize the streamer if we have a protocol and URLs to connect to
     streamer = None
@@ -93,6 +124,8 @@ async def block_until_signal(sigs: List[signal.Signals]):
 
 
 if __name__ == "__main__":
+    threading.excepthook = thread_exception_hook(threading.excepthook)
+
     parser = argparse.ArgumentParser(description="Infer process to run the AI pipeline")
     parser.add_argument(
         "--http-port", type=int, default=8888, help="Port for the HTTP server"

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -26,11 +26,7 @@ def asyncio_exception_handler(loop, context):
     Handles unhandled exceptions in asyncio tasks, logging the error and terminating the application.
     """
     exception = context.get('exception')
-    logging.error(f"Caught unhandled exception in asyncio task: {exception}")
-    if exception:
-        logging.error(f"Traceback:\n{''.join(traceback.format_tb(exception.__traceback__))}")
-
-    logging.error("Terminating due to unhandled exception in asyncio task")
+    logging.error(f"Terminating process due to unhandled exception in asyncio task", exc_info=exception)
     os._exit(1)
 
 
@@ -39,12 +35,8 @@ def thread_exception_hook(original_hook):
     Creates a custom exception hook for threads that logs the error and terminates the application.
     """
     def custom_hook(args):
-        logging.error(f"Caught unhandled exception in thread {args.thread}: {args.exc_value}")
-        logging.error(f"Traceback:\n{''.join(traceback.format_tb(args.exc_traceback))}")
-
-        original_hook(args)
-
-        logging.error("Terminating due to unhandled exception in thread")
+        logging.error("Terminating process due to unhandled exception in thread", exc_info=args.exc_value)
+        original_hook(args) # this is most likely a noop
         os._exit(1)
     return custom_hook
 

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -233,7 +233,7 @@ class LiveVideoToVideoPipeline(Pipeline):
 
         # Collect /proc information
         os_proc_info = {}
-        for proc_file in ["status", "wchan", "io", "stack", "limits", "maps"]:
+        for proc_file in ["status", "wchan", "io"]:
             try:
                 path = f"/proc/{pid}/{proc_file}"
                 if os.path.exists(path):

--- a/runner/requirements.txt
+++ b/runner/requirements.txt
@@ -19,6 +19,7 @@ sentencepiece== 0.2.0
 protobuf==5.27.2
 bitsandbytes==0.43.3
 psutil==6.0.0
+types-psutil==6.0.0.20241011
 PyYAML==6.0.2
 nvidia-ml-py==12.560.30
 pynvml==12.0.0


### PR DESCRIPTION
This creates custom uncaught exception handlers for both asyncio and threading modules,
to make sure we crash the whole process when our code fails to handle an exception.

This is important to catch problems where we are forgetting to handle exceptions and part
of the runner stop working without notice. On the worst case when those exceptions are not
to be fatal, all we need to do is to add an try/except clause and log them. They should not be
uncaught. This is the default behavior in other envs like node and go and idk why python likes
to be the weird one.