### PR TITLE
live/streamer: Avoid IDLE state in the beginning of stream

### DIFF
--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -120,7 +120,7 @@ class ProcessGuardian:
     def _current_state(self) -> str:
         current_time = time.time()
         input = self.status.input_status
-        last_input_time = input.last_input_time or 0
+        last_input_time = input.last_input_time or self.status.start_time
         time_since_last_input = current_time - last_input_time
         if time_since_last_input > 60:
             if time_since_last_input < 90:


### PR DESCRIPTION
Currently the runner will return IDLE on the healthcheck when a stream is starting and hasn't processed any input frames yet. Gotta give it some graceful startup time. This fixes it in a simple way by defaulting the `last_input_time` to the `start_time` of the stream (`start_time` is reset on `reset_stream`).