### PR TITLE
.github: Pin changed-fils to a specific version

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 # v46.0.3
         with:
           files: |
             runner/docker/Dockerfile.live-base


### PR DESCRIPTION
Github action plugin had got hacked and leaked some credentials. They have been rotated and we are pinning the version to avoid any future issues.