### PR TITLE
update to vllm 0.8.4

### DIFF
--- a/runner/app/pipelines/llm.py
+++ b/runner/app/pipelines/llm.py
@@ -150,7 +150,7 @@ class LLMPipeline(Pipeline):
 
         logger.info(f"Model loaded: {self.model_id}")
         logger.info(f"Using GPU memory utilization: {mem_utilization}")
-        self.engine.start_background_loop()
+        #self.engine.start_background_loop()
 
     @staticmethod
     def _get_model_dir() -> str:

--- a/runner/app/pipelines/llm.py
+++ b/runner/app/pipelines/llm.py
@@ -150,7 +150,6 @@ class LLMPipeline(Pipeline):
 
         logger.info(f"Model loaded: {self.model_id}")
         logger.info(f"Using GPU memory utilization: {mem_utilization}")
-        #self.engine.start_background_loop()
 
     @staticmethod
     def _get_model_dir() -> str:

--- a/runner/app/routes/utils.py
+++ b/runner/app/routes/utils.py
@@ -98,20 +98,6 @@ class LLMResponse(BaseModel):
     usage: LLMTokenUsage
     choices: List[LLMChoice]
 
-
-# class LLMStreamChoice(LLMBaseChoice):
-#     delta: LLMMessage
-
-# class LLMNonStreamChoice(LLMBaseChoice):
-#     message: LLMMessage
-
-# class LLMStreamResponse(LLMBaseResponse):
-#     choices: List[LLMStreamChoice]
-
-# class LLMNonStreamResponse(LLMBaseResponse):
-#     choices: List[LLMNonStreamChoice]
-
-
 class LLMRequest(BaseModel):
     messages: List[LLMMessage]
     model: str = ""

--- a/runner/requirements.llm.in
+++ b/runner/requirements.llm.in
@@ -1,4 +1,4 @@
-vllm==0.8.2
+vllm==0.8.4
 diffusers
 accelerate
 transformers

--- a/runner/requirements.llm.in
+++ b/runner/requirements.llm.in
@@ -1,4 +1,4 @@
-vllm==0.6.5
+vllm==0.8.2
 diffusers
 accelerate
 transformers
@@ -20,3 +20,6 @@ sentencepiece
 protobuf
 bitsandbytes
 psutil
+nvidia-ml-py>=12.560.30
+pynvml==12.0.0
+prometheus_client>=0.21.1


### PR DESCRIPTION
Updates llm docker image and pipeline to use vllm 0.8.4. 

This fixes security bug in 0.6.5 that llm pipeline currently uses.

Additional updates:
- cleanup commented out code
- add hardware info reporting requirements.