### PR TITLE
streamer: Debug log for each frame streamId

### DIFF
--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -217,6 +217,9 @@ class PipelineStreamer:
 
                 # TODO accounting for audio output
                 if isinstance(output, AudioOutput):
+                    logging.debug(
+                        f"Output audio received outputStreamId={output.stream_id} numFrames={len(output.frames)}"
+                    )
                     yield output
                     continue
 
@@ -227,7 +230,7 @@ class PipelineStreamer:
                     continue
 
                 logging.debug(
-                    f"Output image received ts={output.timestamp} time_base={output.time_base} resolution={output.image.width}x{output.image.height} mode={output.image.mode}"
+                    f"Output image received outputStreamId={output.stream_id} ts={output.timestamp} time_base={output.time_base} resolution={output.image.width}x{output.image.height} mode={output.image.mode}"
                 )
 
 

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -211,32 +211,31 @@ class PipelineStreamer:
             frame_count = 0
             start_time = 0.0
             while not self.stop_event.is_set():
-                output_frame = await self.process.recv_output()
-                if not output_frame:
+                output = await self.process.recv_output()
+                if not output:
                     continue
 
                 # TODO accounting for audio output
-                if isinstance(output_frame, AudioOutput):
-                    yield output_frame
+                if isinstance(output, AudioOutput):
+                    yield output
                     continue
 
-                if not isinstance(output_frame, VideoOutput):
+                if not isinstance(output, VideoOutput):
                     logging.warning(
-                        f"Unknown output frame type {type(output_frame)}, dropping"
+                        f"Unknown output frame type {type(output)}, dropping"
                     )
                     continue
 
-                output_image = output_frame.frame.image
+                logging.debug(
+                    f"Output image received ts={output.timestamp} time_base={output.time_base} resolution={output.image.width}x{output.image.height} mode={output.image.mode}"
+                )
+
 
                 if not start_time:
                     # only start measuring output FPS after the first frame
                     start_time = time.time()
 
-                logging.debug(
-                    f"Output image received out_width: {output_image.width}, out_height: {output_image.height}"
-                )
-
-                yield output_frame
+                yield output
 
                 # Increment frame count and measure FPS
                 frame_count += 1

--- a/runner/app/live/trickle/frame.py
+++ b/runner/app/live/trickle/frame.py
@@ -61,8 +61,10 @@ class OutputFrame:
 
 class VideoOutput(OutputFrame):
     frame: VideoFrame
-    def __init__(self, frame: VideoFrame):
+    stream_id: str
+    def __init__(self, frame: VideoFrame, stream_id: str):
         self.frame = frame
+        self.stream_id = stream_id
 
     @property
     def image(self):
@@ -82,5 +84,7 @@ class VideoOutput(OutputFrame):
 
 class AudioOutput(OutputFrame):
     frames: List[AudioFrame]
-    def __init__(self, frames: List[AudioFrame]):
+    stream_id: str
+    def __init__(self, frames: List[AudioFrame], stream_id: str):
         self.frames = frames
+        self.stream_id = stream_id


### PR DESCRIPTION
We recently started noticing issues where frames from the previous streams were delivered to the new
streams. It seems like the fix [didn't really work](https://eu-metrics-monitoring.livepeer.monster/grafana/explore?schemaVersion=1&panes=%7B%22che%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcontainer%3D%5C%22live-video-to-video_comfyui_8900%5C%22%7D%20%7C%3D%20%5C%22Invalid%20argument:%20%27%25d.ts%27%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22direction%22:%22forward%22%7D%5D,%22range%22:%7B%22from%22:%22now-2d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1). Let's add it on debug logs so we can debug.
