### PR TITLE
Encoder error workaround

### DIFF
--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -36,7 +36,7 @@ class PipelineProcess:
         self.done = self.ctx.Event()
         self.process = self.ctx.Process(target=self.process_loop, args=())
         self.start_time = 0.0
-        self.stream_id = ""
+        self.request_id = ""
 
     async def stop(self):
         self._stop_sync()
@@ -133,7 +133,7 @@ class PipelineProcess:
         def _handle_logging_params(params: dict) -> bool:
             if isinstance(params, dict) and "request_id" in params and "stream_id" in params:
                 logging.info(f"PipelineProcess: Resetting logging fields with request_id={params['request_id']}, stream_id={params['stream_id']}")
-                self.stream_id = params["stream_id"]
+                self.request_id = params["request_id"]
                 self._reset_logging_fields(
                     params["request_id"], params["stream_id"]
                 )
@@ -191,10 +191,10 @@ class PipelineProcess:
                         input_frame.log_timestamps["pre_process_frame"] = time.time()
                         output_image = pipeline.process_frame(input_frame.image)
                         input_frame.log_timestamps["post_process_frame"] = time.time()
-                        output_frame = VideoOutput(input_frame.replace_image(output_image), self.stream_id)
+                        output_frame = VideoOutput(input_frame.replace_image(output_image), self.request_id)
                         self.output_queue.put(output_frame)
                     elif isinstance(input_frame, AudioFrame):
-                        self.output_queue.put(AudioOutput([input_frame], self.stream_id))
+                        self.output_queue.put(AudioOutput([input_frame], self.request_id))
                         # TODO wire in a proper pipeline here
                     else:
                         report_error(f"Unsupported input frame type {type(input_frame)}")

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -207,6 +207,7 @@ class PipelineStreamer:
         logging.info("Ingress loop ended")
 
     async def run_egress_loop(self):
+        request_id = self.request_id
         async def gen_output_frames() -> AsyncGenerator[OutputFrame, None]:
             frame_count = 0
             start_time = 0.0
@@ -220,6 +221,11 @@ class PipelineStreamer:
                     logging.debug(
                         f"Output audio received outputRequestId={output.request_id} numFrames={len(output.frames)}"
                     )
+                    if output.request_id != request_id:
+                        logging.warning(
+                            f"Output audio request ID mismatch: expected {request_id}, got {output.request_id}, skipping frame"
+                        )
+                        continue
                     yield output
                     continue
 
@@ -228,7 +234,11 @@ class PipelineStreamer:
                         f"Unknown output frame type {type(output)}, dropping"
                     )
                     continue
-
+                if output.request_id != request_id:
+                    logging.warning(
+                        f"Output video request ID mismatch: expected {request_id}, got {output.request_id}, skipping frame"
+                    )
+                    continue
                 logging.debug(
                     f"Output image received outputRequestId={output.request_id} ts={output.timestamp} time_base={output.time_base} resolution={output.image.width}x{output.image.height} mode={output.image.mode}"
                 )

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -236,7 +236,7 @@ class PipelineStreamer:
                     continue
                 if output.request_id != request_id:
                     logging.warning(
-                        f"Output video request ID mismatch: expected {request_id}, got {output.request_id}, skipping frame"
+                        f"Output video request ID mismatch: expected {request_id}, got {output.request_id}, dropping frame"
                     )
                     continue
                 logging.debug(

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -218,7 +218,7 @@ class PipelineStreamer:
                 # TODO accounting for audio output
                 if isinstance(output, AudioOutput):
                     logging.debug(
-                        f"Output audio received outputStreamId={output.stream_id} numFrames={len(output.frames)}"
+                        f"Output audio received outputRequestId={output.request_id} numFrames={len(output.frames)}"
                     )
                     yield output
                     continue
@@ -230,7 +230,7 @@ class PipelineStreamer:
                     continue
 
                 logging.debug(
-                    f"Output image received outputStreamId={output.stream_id} ts={output.timestamp} time_base={output.time_base} resolution={output.image.width}x{output.image.height} mode={output.image.mode}"
+                    f"Output image received outputRequestId={output.request_id} ts={output.timestamp} time_base={output.time_base} resolution={output.image.width}x{output.image.height} mode={output.image.mode}"
                 )
 
 

--- a/runner/app/live/trickle/frame.py
+++ b/runner/app/live/trickle/frame.py
@@ -61,7 +61,7 @@ class OutputFrame:
 
 class VideoOutput(OutputFrame):
     frame: VideoFrame
-    stream_id: str
+    request_id: str
     def __init__(self, frame: VideoFrame, request_id: str):
         self.frame = frame
         self.request_id = request_id

--- a/runner/app/live/trickle/frame.py
+++ b/runner/app/live/trickle/frame.py
@@ -62,9 +62,9 @@ class OutputFrame:
 class VideoOutput(OutputFrame):
     frame: VideoFrame
     stream_id: str
-    def __init__(self, frame: VideoFrame, stream_id: str):
+    def __init__(self, frame: VideoFrame, request_id: str):
         self.frame = frame
-        self.stream_id = stream_id
+        self.request_id = request_id
 
     @property
     def image(self):
@@ -85,6 +85,6 @@ class VideoOutput(OutputFrame):
 class AudioOutput(OutputFrame):
     frames: List[AudioFrame]
     stream_id: str
-    def __init__(self, frames: List[AudioFrame], stream_id: str):
+    def __init__(self, frames: List[AudioFrame], request_id: str):
         self.frames = frames
-        self.stream_id = stream_id
+        self.request_id = request_id


### PR DESCRIPTION
- Change the DEBUG log from `stream_id` to `request_id` (I think it's the `request_id` that represents the single streaming session in our system)
- Add frame dropping in case the frame request ID does not match the request ID currently being processed by the Runner