### PR TITLE
add depth-anything-large engine to dl_checkpoints.sh

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -123,7 +123,8 @@ function build_tensorrt_models() {
   # Depth-Anything-Tensorrt
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/ComfyUI/models/tensorrt/depth-anything && \
-                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
+                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py --trt_path=./depth_anything_v2_vitl-fp16.engine --onnx-path=./depth_anything_v2_vitl.onnx && \
+                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py --trt_path=./depth_anything_vitl14-fp16.engine --onnx_path=./depth_anything_vitl14.onnx && \
                 adduser $(id -u -n) && \
                 chown -R $(id -u -n):$(id -g -n) /models" ||
     (


### PR DESCRIPTION
Adds a new depth anything engine compilation to `dl_checkpoints.sh` for `depth_anything_v2_vitl-fp16.engine`

This change is for https://github.com/livepeer/comfystream/pull/79 and requires the additional `depth_anything_v2_vitl.onnx` model from here https://github.com/livepeer/comfystream/pull/79/files#diff-2ecea05f303168744235a97f61ba4f203f75083eabd103e0ed223866bdd2b296R26