### PR TITLE
make sure we run only one dl_checkpoints.sh at a time

### DIFF
--- a/.github/workflows/ai-runner-models.yaml
+++ b/.github/workflows/ai-runner-models.yaml
@@ -80,6 +80,9 @@ jobs:
       matrix:
         gpu: [rtx-4090]
     runs-on: ${{ matrix.gpu }}
+    concurrency:
+      group: download-build-tensorrt-models-${{ matrix.gpu }}
+      cancel-in-progress: false
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
`dl_checkpoints.sh --tensorrt` runs directly on the single rtx-4090 server so make sure they won't interfere with other simultaneous builds as they don't run inside docker