### PR TITLE
Revert "add depth-anything-large engine to dl_checkpoints.sh"

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -123,8 +123,7 @@ function build_tensorrt_models() {
   # Depth-Anything-Tensorrt
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/ComfyUI/models/tensorrt/depth-anything && \
-                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py --trt_path=./depth_anything_v2_vitl-fp16.engine --onnx-path=./depth_anything_v2_vitl.onnx && \
-                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py --trt_path=./depth_anything_vitl14-fp16.engine --onnx_path=./depth_anything_vitl14.onnx && \
+                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
                 adduser $(id -u -n) && \
                 chown -R $(id -u -n):$(id -g -n) /models" ||
     (


### PR DESCRIPTION
Reverting since this cannot be merged until after live-base-comfyui is updated with https://hub.docker.com/layers/livepeer/comfyui-base/latest/images/sha256-df93313a4a01c4b5197fcdd5e75c1c4eb85e4cfcc9ce8e1066926beaeb69db44 (the new model is not in models.yaml until this version)

Will reopen with this change after we're ready to ship new comfyui-base image