### PR TITLE
Fix noop pipeline

### DIFF
--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -304,7 +304,7 @@ class ComfyUI(Pipeline):
         result_image_np = (result_tensor * 255).byte()
         result_image = Image.fromarray(result_image_np.cpu().numpy())
         return VideoOutput(frame.replace_image(result_image), request_id)
-    
+
     async def update_params(self, **params):
         new_params = ComfyUIParams(**params)
         logging.info(f"Updating ComfyUI Pipeline Prompt: {new_params.prompt}")

--- a/runner/app/live/pipelines/noop.py
+++ b/runner/app/live/pipelines/noop.py
@@ -13,11 +13,11 @@ class Noop(Pipeline):
   async def put_video_frame(self, frame: VideoFrame):
     await self.frame_queue.put(frame)
 
-  async def get_processed_video_frame(self) -> VideoOutput:
+  async def get_processed_video_frame(self, request_id: str = '') -> VideoOutput:
     frame = await self.frame_queue.get()
     processed_frame = frame.image.convert("RGB")
-    return VideoOutput(frame.replace_image(processed_frame))
-  
+    return VideoOutput(frame.replace_image(processed_frame), request_id)
+
   async def initialize(self, **params):
     logging.info(f"Initializing Noop pipeline with params: {params}")
     logging.info("Pipeline initialization complete")


### PR DESCRIPTION
This seems to have broken in https://github.com/livepeer/ai-runner/pull/479

Even with this PR, it still doesn't run due to this line expecting a hard-coded path to python that doesn't exist:

https://github.com/livepeer/ai-runner/blob/9e21e45480bf3112388f5b4b6bfb11df3ea51522/runner/app/pipelines/live_video_to_video.py#L110

When I change the executable back to `python` for local testing then it works fine, but presumably it was changed for a reason so I am not sure the best way to sort that out, maybe by updating the PATH env var in the container instead of hard-coding it here.