### PR TITLE
lv2v: Restart infer.py process and cleanup previous stream quickly

### DIFF
--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -73,6 +73,7 @@ async def cleanup_last_stream():
             params = StartStreamParams(**json.load(f))
         os.remove(last_params_file)
 
+        logging.info(f"Cleaning up last stream trickle channels for request_id={params.request_id} subscribe_url={params.subscribe_url} publish_url={params.publish_url} control_url={params.control_url} events_url={params.events_url}")
         protocol = TrickleProtocol(
             params.subscribe_url,
             params.publish_url,
@@ -166,7 +167,7 @@ async def handle_get_status(request: web.Request):
 async def start_http_server(
     port: int, process: ProcessGuardian, streamer: Optional[PipelineStreamer] = None
 ):
-    await cleanup_last_stream()
+    asyncio.create_task(cleanup_last_stream())
 
     app = web.Application()
     app["process"] = process

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -123,6 +123,10 @@ class LiveVideoToVideoPipeline(Pipeline):
             raise InferenceError(f"Error starting infer.py: {e}")
 
     def monitor_process(self):
+        # Wait 1 sec before starting to monitor the process. This gives it some
+        # time to start and also ensures we won't restart the process too often.
+        time.sleep(1)
+
         while True:
             if not self.process:
                 logging.error("No process to monitor")


### PR DESCRIPTION
This makes sure our recovery from process crashes is faster. Instead of relying on
gateway timeouts to detect the runner went away, and on worker timeouts to realize
the process crashed:
- Restart the `infer.py` process directly from the API process
- Upon startup, make sure we cleanup the previous stream trickle channels to notify gateway immediately

## Implementation Detail

On the second item, cleaning up the previous stream, I had thought of a different
implementation where the runner API kept the "previous params" state instead. This would
be less future-proof tho, since we'd lose this integration point once we remove the infer.py
as a separate process. The current implementation is also more resilient against docker container
crashes, we'd just need to write the last params file on a mounted volume (left this as a future
evolution, but it's much easier to evolve from this than if we had a state in memory).