### PR TITLE
fix: use conda env only when pipeline is comfyui

### DIFF
--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -107,10 +107,7 @@ class LiveVideoToVideoPipeline(Pipeline):
             raise ConnectionError(f"Failed to get status: {e}")
 
     def start_process(self, **kwargs):
-        if kwargs.get("pipeline") == "comfyui":
-            cmd = ["conda", "run", "--no-capture-output", "-n", "comfystream", "python", str(self.infer_script_path)]
-        else:
-            cmd = ["python", str(self.infer_script_path)]
+        cmd = [sys.executable, str(self.infer_script_path)]
 
         # Add any additional kwargs as command-line arguments
         for key, value in kwargs.items():

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -110,7 +110,7 @@ class LiveVideoToVideoPipeline(Pipeline):
         if kwargs.get("pipeline") == "comfyui":
             cmd = ["conda", "run", "--no-capture-output", "-n", "comfystream", "python", str(self.infer_script_path)]
         else:
-            cmd = [str(self.infer_script_path)]
+            cmd = ["python", str(self.infer_script_path)]
 
         # Add any additional kwargs as command-line arguments
         for key, value in kwargs.items():

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -107,7 +107,10 @@ class LiveVideoToVideoPipeline(Pipeline):
             raise ConnectionError(f"Failed to get status: {e}")
 
     def start_process(self, **kwargs):
-        cmd = [str("/workspace/miniconda3/envs/comfystream/bin/python"), str(self.infer_script_path)]
+        if kwargs.get("pipeline") == "comfyui":
+            cmd = ["conda", "run", "--no-capture-output", "-n", "comfystream", "python", str(self.infer_script_path)]
+        else:
+            cmd = [str(self.infer_script_path)]
 
         # Add any additional kwargs as command-line arguments
         for key, value in kwargs.items():

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -101,6 +101,7 @@ function download_live_models() {
   docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
   docker run --rm -v ./models:/models --gpus all -l ComfyUI-Setup-Models $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/comfystream && \
+                 source /workspace/miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
                  python src/comfystream/scripts/setup_models.py --workspace /workspace/ComfyUI && \
                  adduser $(id -u -n) && \
                  chown -R $(id -u -n):$(id -g -n) /models" ||
@@ -123,6 +124,7 @@ function build_tensorrt_models() {
   # Depth-Anything-Tensorrt
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/ComfyUI/models/tensorrt/depth-anything && \
+                source /workspace/miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
                 python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
                 adduser $(id -u -n) && \
                 chown -R $(id -u -n):$(id -g -n) /models" ||
@@ -134,6 +136,7 @@ function build_tensorrt_models() {
   # Dreamshaper-8-Dmd-1kstep
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/comfystream/src/comfystream/scripts && \
+                 source /workspace/miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
                  python ./build_trt.py \
                 --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
                 --out-engine /workspace/ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\\\$stat-b-1-h-512-w-512_00001_.engine && \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -4,6 +4,7 @@
 
 # ComfyUI image configuration
 AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
+CONDA_PYTHON="/workspace/miniconda3/envs/comfystream/bin/python"
 
 # Checks HF_TOKEN and huggingface-cli login status and throw warning if not authenticated.
 check_hf_auth() {
@@ -101,8 +102,7 @@ function download_live_models() {
   docker image tag $AI_RUNNER_COMFYUI_IMAGE livepeer/ai-runner:live-app-comfyui
   docker run --rm -v ./models:/models --gpus all -l ComfyUI-Setup-Models $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/comfystream && \
-                 source /workspace/miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
-                 python src/comfystream/scripts/setup_models.py --workspace /workspace/ComfyUI && \
+                 $CONDA_PYTHON src/comfystream/scripts/setup_models.py --workspace /workspace/ComfyUI && \
                  adduser $(id -u -n) && \
                  chown -R $(id -u -n):$(id -g -n) /models" ||
     (
@@ -124,8 +124,7 @@ function build_tensorrt_models() {
   # Depth-Anything-Tensorrt
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/ComfyUI/models/tensorrt/depth-anything && \
-                source /workspace/miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
-                python /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
+                $CONDA_PYTHON /workspace/ComfyUI/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \
                 adduser $(id -u -n) && \
                 chown -R $(id -u -n):$(id -g -n) /models" ||
     (
@@ -136,11 +135,10 @@ function build_tensorrt_models() {
   # Dreamshaper-8-Dmd-1kstep
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_COMFYUI_IMAGE \
     bash -c "cd /workspace/comfystream/src/comfystream/scripts && \
-                 source /workspace/miniconda3/etc/profile.d/conda.sh && conda activate comfystream && \
-                 python ./build_trt.py \
+                $CONDA_PYTHON ./build_trt.py \
                 --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
                 --out-engine /workspace/ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\\\$stat-b-1-h-512-w-512_00001_.engine && \
-                 adduser $(id -u -n) && \
+                adduser $(id -u -n) && \
                  chown -R $(id -u -n):$(id -g -n) /models" ||
     (
       echo "failed ComfyUI build_trt.py"


### PR DESCRIPTION
This change runs the noop pipeline normally and ensures the comfyui pipeline is started in the comfystream environment