### PR TITLE
Add missing logging import to last-value-cache

### DIFF
--- a/runner/app/live/streamer/protocol/last_value_cache.py
+++ b/runner/app/live/streamer/protocol/last_value_cache.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from typing import Optional, TypeVar, Generic, Callable
 


### PR DESCRIPTION
Fixes an exception ... don't think this has happened in prod but I managed to trigger it somehow in dev.