### PR TITLE
Re-enable encoder retries.

### DIFF
--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -11,7 +11,7 @@ from .trickle_publisher import TricklePublisher
 from .decoder import decode_av
 from .encoder import encode_av
 
-MAX_ENCODER_RETRIES = 1
+MAX_ENCODER_RETRIES = 3
 ENCODER_RETRY_RESET_SECONDS = 120 # reset retry counter after 2 minutes
 
 async def run_subscribe(subscribe_url: str, image_callback, put_metadata, monitoring_callback):


### PR DESCRIPTION
We still get encode_av errors sometimes so let's see if retrying helps this time, instead of shutting down the stream.