### PR TITLE
feat/remove old docker file path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
             "args": {
                 "PIPELINE": "comfyui"
             },
-            // "dockerfile": "../Dockerfile",
             // "dockerfile": "../docker/Dockerfile.text_to_speech",
             "context": "../runner"
         },


### PR DESCRIPTION
This pull request removes the old Dockerfile path from the dev container, as the file has already been moved.