### PR TITLE
live/process: Fix ComfyUI pipeline cleanup

### DIFF
--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -99,5 +99,5 @@ class ComfyUI(Pipeline):
 
     async def stop(self):
         logging.info("Stopping ComfyUI pipeline")
-        await self.client.stop()
+        await self.client.cleanup()
         logging.info("ComfyUI pipeline stopped")


### PR DESCRIPTION
We've been having a couple issues in prod that I believe are related to a broken cleanup logic
for the `comfyui` (comfystream) pipeline. My theory for what happens is:
- `process_guardian` tries to kill the process for some reason (e.g. inference hanged)
- calls `pipeline.stop()`, but t he implementation on comfyui calls a `cleint.stop()` which doesn't exist
[`Error stopping pipeline: 'ComfyStreamClient' object has no attribute 'stop'`](https://eu-metrics-monitoring.livepeer.live/grafana/goto/ZgaViZxHR?orgId=1)
- comfystream never shuts down, its tasks stay running
- Joining the process fails because asyncio loop never ends
- [Kill leaves the process zombie and sometimes consuming a whole core](https://discord.com/channels/423160867534929930/1366364524944425020/1366364882454446100)
- New comfystream process also never starts, [node gets into a bad state where it doesn't do any inference](https://discord.com/channels/423160867534929930/1335838529317502986/1366909911681863874). I suspect this might be due to some shared resource that is locked by the previous process, or maybe resource consumption.

This fixes the issue in 2 ways:
- Fixes the cleanup logic on the comfyui pipeline, callign the right function from comfystream client ([`cleanup()`](https://github.com/livepeer/comfystream/blob/2a8978140285345100d8afb6e2739293153cd12c/src/comfystream/client.py#L46))
- Makes sure we `join` the process after killing it, since we still need to collect OS resources. This _might_ prevent the zombie processes in case sth similar happens again.