### PR TITLE
fix: comfyui pipeline shutdown logic

### DIFF
--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=livepeer/comfyui-base@sha256:4435bad85c3a2fce2b491135bee49eedb8edbd8bdf5d124cb0a95a1d4ecb6856
+ARG BASE_IMAGE=livepeer/comfyui-base@sha256:3cc56a54ce5972bde1747210ba122a100733ec32127278e932010bcafd701889
 FROM ${BASE_IMAGE}
 
 # -----------------------------------------------------------------------------

--- a/runner/gateway.openapi.yaml
+++ b/runner/gateway.openapi.yaml
@@ -525,8 +525,7 @@ components:
     AudioResponse:
       properties:
         audio:
-          allOf:
-          - $ref: '#/components/schemas/MediaURL'
+          $ref: '#/components/schemas/MediaURL'
           description: The generated audio.
       type: object
       required:
@@ -827,8 +826,7 @@ components:
     HTTPError:
       properties:
         detail:
-          allOf:
-          - $ref: '#/components/schemas/APIError'
+          $ref: '#/components/schemas/APIError'
           description: Detailed error information.
       type: object
       required:
@@ -878,11 +876,9 @@ components:
           title: Finish Reason
           default: ''
         delta:
-          allOf:
-          - $ref: '#/components/schemas/LLMMessage'
+          $ref: '#/components/schemas/LLMMessage'
         message:
-          allOf:
-          - $ref: '#/components/schemas/LLMMessage'
+          $ref: '#/components/schemas/LLMMessage'
       type: object
       required:
       - index
@@ -1010,6 +1006,7 @@ components:
             argument.
           default: ''
         params:
+          additionalProperties: true
           type: object
           title: Params
           description: Initial parameters for the pipeline.

--- a/runner/openapi.yaml
+++ b/runner/openapi.yaml
@@ -569,8 +569,7 @@ components:
     AudioResponse:
       properties:
         audio:
-          allOf:
-          - $ref: '#/components/schemas/MediaURL'
+          $ref: '#/components/schemas/MediaURL'
           description: The generated audio.
       type: object
       required:
@@ -930,8 +929,7 @@ components:
     HTTPError:
       properties:
         detail:
-          allOf:
-          - $ref: '#/components/schemas/APIError'
+          $ref: '#/components/schemas/APIError'
           description: Detailed error information.
       type: object
       required:
@@ -1035,11 +1033,9 @@ components:
           title: Finish Reason
           default: ''
         delta:
-          allOf:
-          - $ref: '#/components/schemas/LLMMessage'
+          $ref: '#/components/schemas/LLMMessage'
         message:
-          allOf:
-          - $ref: '#/components/schemas/LLMMessage'
+          $ref: '#/components/schemas/LLMMessage'
       type: object
       required:
       - index
@@ -1167,6 +1163,7 @@ components:
             argument.
           default: ''
         params:
+          additionalProperties: true
           type: object
           title: Params
           description: Initial parameters for the pipeline.


### PR DESCRIPTION
This change resolves an error when shutting down the comfyui pipeline via `_restart_process` in [process_guardian.py](https://github.com/livepeer/ai-runner/blob/21c5539a014f32c7371892b9ae53bf81fb77821e/runner/app/live/streamer/process_guardian.py#L173) due to the various i/o loops started by `run_pipeline_loops` within `PipelineProcess` not stopping gracefully with the pipeline. 

`_run_pipeline_loops` has been updated to include proper error handling and stop all running tasks when any of them are cancelled or stopped.

`pipeline` is also updated to `self.pipeline` instead of passing the variable to functions in the same class
