### PR TITLE
trickle: Start subscribing at the current seq, rather than the next

### DIFF
--- a/runner/app/live/trickle/trickle_publisher.py
+++ b/runner/app/live/trickle/trickle_publisher.py
@@ -33,7 +33,7 @@ class TricklePublisher:
             asyncio.create_task(self._run_post(url, queue))
             return queue
         except aiohttp.ClientError as e:
-            logging.error(f"Failed to complete POST for {self.streamIdx()}: {e}")
+            logging.error(f"Failed to complete POST for {url}: {e}")
             return None
 
     async def _run_post(self, url, queue):

--- a/runner/app/live/trickle/trickle_subscriber.py
+++ b/runner/app/live/trickle/trickle_subscriber.py
@@ -4,9 +4,9 @@ import logging
 import sys
 
 class TrickleSubscriber:
-    def __init__(self, url: str, max_retries=5):
+    def __init__(self, url: str, start_seq=-2, max_retries=5):
         self.base_url = url
-        self.idx = -1  # Start with -1 for 'latest' index
+        self.idx = start_seq
         self.pending_get: aiohttp.ClientResponse | None = None  # Pre-initialized GET request
         self.lock = asyncio.Lock()  # Lock to manage concurrent access
         self.session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False))


### PR DESCRIPTION
This helps mitigate a bit of delay if the runner starts subscribing to a channel after the first segment has already started writing. This would have made the runner start waiting for the *next* segment (1s on average, up to 2s), which seems to happen roughly 2/3s of the time by eyeballing this histogram. Requires https://github.com/livepeer/go-livepeer/pull/3552

<img width="599" alt="image" src="https://github.com/user-attachments/assets/aa76ee1a-0cae-4511-852d-0035b602f1d8" />
