### PR TITLE
live/streamer: Shut down runner on inference process restart

### DIFF
--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -38,6 +38,9 @@ class PipelineProcess:
         self.start_time = 0.0
         self.request_id = ""
 
+    def is_alive(self):
+        return self.process.is_alive()
+
     async def stop(self):
         self._stop_sync()
 

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -210,6 +210,10 @@ class ProcessGuardian:
                 await asyncio.sleep(1)
                 if not self.process or self.process.done.is_set():
                     continue
+                if not self.process.is_alive():
+                    logging.error("Process is not alive. Restarting...")
+                    await self._restart_process()
+                    continue
 
                 last_error = self.process.get_last_error()
                 if last_error:

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -126,6 +126,12 @@ class ProcessGuardian:
         return status
 
     def _current_state(self) -> str:
+        # Hot fix: the comfyui pipeline process is having trouble shutting down and causes restarts not to recover.
+        # So return an error state if the process has restarted so the worker will restart the whole container.
+        # TODO: Remove this once pipeline shutodwn is fixed and restarting process is useful again.
+        if self.status.inference_status.restart_count > 0:
+            return PipelineState.ERROR
+
         current_time = time.time()
         input = self.status.input_status
         last_input_time = input.last_input_time or self.status.start_time

--- a/runner/app/live/streamer/status.py
+++ b/runner/app/live/streamer/status.py
@@ -42,6 +42,7 @@ class PipelineState:
     ONLINE = "ONLINE"
     DEGRADED_INPUT = "DEGRADED_INPUT"
     DEGRADED_INFERENCE = "DEGRADED_INFERENCE"
+    ERROR = "ERROR"
 
 class PipelineStatus(BaseModel):
     """Holds metrics for the pipeline streamer"""

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -75,7 +75,7 @@ class LiveVideoToVideoPipeline(Pipeline):
             # The infer process is supposed to be always running, so if it's
             # gone it means an ERROR and the worker is allowed to kill us.
             logging.error("[HEALTHCHECK] Infer process is not running")
-            return HealthCheck(status="ERROR", version=self.version)
+            return HealthCheck(status="ERROR")
 
         try:
             conn = http.client.HTTPConnection("localhost", 8888)
@@ -91,8 +91,11 @@ class LiveVideoToVideoPipeline(Pipeline):
 
             pipe_status = PipelineStatus(**json.loads(response.read().decode()))
             return HealthCheck(
-                status="IDLE" if pipe_status.state == "OFFLINE" else "OK",
-                version=self.version,
+                status=(
+                    "IDLE" if pipe_status.state == "OFFLINE"
+                    else "ERROR" if pipe_status.state == "ERROR"
+                    else "OK"
+                ),
             )
         except Exception as e:
             logging.error(f"[HEALTHCHECK] Failed to get status: {type(e).__name__}: {str(e)}")


### PR DESCRIPTION
We've been getting production issues where we can't restart the inference process anymore
as it hangs to the GPU and doesn't let new processes start up. We are fixing that problem, but
while we figure it out this is to avoid having zombie runners sticking around indefinitely.


2 extra changes:
- added a quick fix to also restart inference process immediately in case it exits (together with the temp fix, it means immediately shutting down the runner)
- actually built a new state to the pipeline runner which is propagated to the worker. the idea is that we can return this `ERROR` state with some other logic as well (e.g. we're restarting process a couple times and it doesn't work). 
  - Right now the worker will still wait for 2 consecutive `ERROR`s before restarting the container, 
but in the future we can make it react immediately.

--- 

### Rollback instructions

That said, when we fix the `comfyui` shutdown logic we only need to revert the `[HOTFIX]` commit,
but not the whole PR merge or we'll miss the "extra changes" above that we actually wanna keep.