### PR TITLE
live/streamer: Quick stream failover on process restart

### DIFF
--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -1,11 +1,18 @@
 import asyncio
 import logging
 import time
-from typing import Awaitable, Callable, Optional
+from typing import Optional
+import abc
 from trickle import InputFrame, OutputFrame
 
 from .process import PipelineProcess
 from .status import PipelineState, PipelineStatus
+
+
+class ProcessCallbacks(abc.ABC):
+    @abc.abstractmethod
+    async def emit_monitoring_event(self, event_data: dict) -> None:
+        ...
 
 
 class ProcessGuardian:
@@ -20,9 +27,9 @@ class ProcessGuardian:
     ):
         self.pipeline = pipeline
         self.params = params
-        self.monitoring_callback = _noop_callback
+        self.callbacks: ProcessCallbacks = _NoopProcessCallbacks()
 
-        self.process = None
+        self.process: Optional[PipelineProcess] = None
         self.monitor_task = None
         self.stream_running = False
         self.status = PipelineStatus(pipeline=pipeline, start_time=0).update_params(params, False)
@@ -46,7 +53,7 @@ class ProcessGuardian:
         if self.process:
             await self.process.stop()
             self.process = None
-    
+
     def stop_stream(self):
         self.stream_running = False
 
@@ -55,13 +62,13 @@ class ProcessGuardian:
         request_id: str,
         stream_id: str,
         params: dict,
-        monitoring_callback: Callable[[dict], Awaitable[None]],
+        callbacks: ProcessCallbacks | None = None,
     ):
         self.stream_running = True
         if not self.process:
             raise RuntimeError("Process not running")
         self.status = PipelineStatus(pipeline=self.pipeline, start_time=time.time())
-        self.monitoring_callback = monitoring_callback
+        self.callbacks = callbacks or _NoopProcessCallbacks()
         self.process.reset_stream(request_id, stream_id)
         await self.update_params(params)
 
@@ -101,7 +108,7 @@ class ProcessGuardian:
         self.process.update_params(params)
         self.status.update_params(params)
 
-        await self.monitoring_callback(
+        await self.callbacks.emit_monitoring_event(
             {
                 "type": "params_update",
                 "pipeline": self.pipeline,
@@ -195,7 +202,7 @@ class ProcessGuardian:
             self.status.inference_status.last_error = error_msg
             self.status.inference_status.last_error_time = error_time
 
-        await self.monitoring_callback(
+        await self.callbacks.emit_monitoring_event(
             {
                 "type": "restart",
                 "pipeline": self.pipeline,
@@ -226,7 +233,7 @@ class ProcessGuardian:
                     error_msg, error_time = last_error
                     self.status.inference_status.last_error = error_msg
                     self.status.inference_status.last_error_time = error_time
-                    await self.monitoring_callback(
+                    await self.callbacks.emit_monitoring_event(
                         {
                             "type": "error",
                             "pipeline": self.pipeline,
@@ -298,5 +305,6 @@ def calculate_rolling_fps(previous_fps: float, previous_frame_time: float):
     return (now, new_fps)
 
 
-async def _noop_callback(_):
-    pass
+class _NoopProcessCallbacks(ProcessCallbacks):
+    async def emit_monitoring_event(self, event_data: dict) -> None:
+        pass

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -14,6 +14,10 @@ class ProcessCallbacks(abc.ABC):
     async def emit_monitoring_event(self, event_data: dict) -> None:
         ...
 
+    @abc.abstractmethod
+    def on_before_process_restart(self, restart_count: int) -> None:
+        ...
+
 
 class ProcessGuardian:
     """
@@ -187,6 +191,8 @@ class ProcessGuardian:
         if not self.process:
             raise RuntimeError("Process not started")
 
+        self.callbacks.on_before_process_restart(self.status.inference_status.restart_count)
+
         # Capture logs before stopping the process
         restart_logs = self.process.get_recent_logs()
         last_error = self.process.get_last_error()
@@ -307,4 +313,7 @@ def calculate_rolling_fps(previous_fps: float, previous_frame_time: float):
 
 class _NoopProcessCallbacks(ProcessCallbacks):
     async def emit_monitoring_event(self, event_data: dict) -> None:
+        pass
+
+    def on_before_process_restart(self, restart_count: int) -> None:
         pass

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -9,7 +9,7 @@ from asyncio import Lock
 import cv2
 from PIL import Image
 
-from .process_guardian import ProcessGuardian
+from .process_guardian import ProcessGuardian, ProcessCallbacks
 from .protocol.protocol import StreamProtocol
 from .status import timestamp_to_ms
 from trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutput
@@ -17,7 +17,7 @@ from trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutpu
 fps_log_interval = 10
 status_report_interval = 10
 
-class PipelineStreamer:
+class PipelineStreamer(ProcessCallbacks):
     def __init__(
         self,
         protocol: StreamProtocol,
@@ -43,7 +43,7 @@ class PipelineStreamer:
             raise RuntimeError("Streamer already started")
 
         await self.process.reset_stream(
-            self.request_id, self.stream_id, params, self._emit_monitoring_event
+            self.request_id, self.stream_id, params, self
         )
 
         self.stop_event.clear()
@@ -58,9 +58,8 @@ class PipelineStreamer:
             run_in_background("control_loop", self.run_control_loop()),
         ]
         # auxiliary tasks that are not critical to the supervisor, but which we want to run
-        self.auxiliary_tasks = [
-            
-        ]
+        # TODO: maybe remove this since we had to move the control loop to main tasks
+        self.auxiliary_tasks: list[asyncio.Task] = []
         self.tasks_supervisor_task = run_in_background(
             "tasks_supervisor", self.tasks_supervisor()
         )
@@ -128,7 +127,7 @@ class PipelineStreamer:
                 next_report += status_report_interval
 
             status = self.process.get_status(clear_transient=True)
-            await self._emit_monitoring_event(status.model_dump())
+            await self.emit_monitoring_event(status.model_dump())
 
             last_input_time = max(
                 status.input_status.last_input_time or 0, status.start_time
@@ -140,7 +139,7 @@ class PipelineStreamer:
                 )
                 self.stop_event.set()
 
-    async def _emit_monitoring_event(self, event: dict, queue_event_type: str = "ai_stream_events"):
+    async def emit_monitoring_event(self, event: dict, queue_event_type: str = "ai_stream_events"):
         """Protected method to emit monitoring event with lock"""
         event["timestamp"] = timestamp_to_ms(time.time())
         logging.info(f"Emitting monitoring event: {event}")

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -139,6 +139,12 @@ class PipelineStreamer(ProcessCallbacks):
                 )
                 self.stop_event.set()
 
+    def on_before_process_restart(self, restart_count: int) -> None:
+        # Restarting the process will take a couple of time, so we stop the stream
+        # before it happens so the gateway/app can switch to a functioning O ASAP.
+        logging.info(f"Stopping streamer due to process restart restart_count={restart_count}")
+        self.stop_event.set()
+
     async def emit_monitoring_event(self, event: dict, queue_event_type: str = "ai_stream_events"):
         """Protected method to emit monitoring event with lock"""
         event["timestamp"] = timestamp_to_ms(time.time())


### PR DESCRIPTION
This is to make sure we (the gateway/app) quickly failover to a different runner when the inference
process crashes. Otherwise they would have to wait for at least 30s until it comes back.

The risk of this change is in case someone finds out a prompt that always crashes the process. This 
would make it a kryptonite that could take our whole infra if the gateway/app retries indefinitely 💥 

We haven't seen any of that until now + if we have a reasonable number of app/gateway retries this
could be somewhat safe to merge anyway. 

This is built on top of #549 but is unrelated. Only implemented together but decided to put out for review separately.