### PR TITLE
Catch all exceptions from trickle subscribe preconnects.

### DIFF
--- a/runner/app/live/trickle/trickle_subscriber.py
+++ b/runner/app/live/trickle/trickle_subscriber.py
@@ -56,8 +56,8 @@ class TrickleSubscriber:
                 resp.release()
                 logging.error(f"Trickle sub Failed GET {url} status code: {resp.status}, msg: {body}")
 
-            except aiohttp.ClientError as e:
-                logging.error(f"Trickle sub Failed to complete GET {url} error: {e}")
+            except Exception:
+                logging.exception(f"Trickle sub Failed to complete GET {url}", stack_info=True)
 
             if attempt < self.max_retries - 1:
                 await asyncio.sleep(0.5)


### PR DESCRIPTION
Sometimes we get Timeouts (default ~5 minutes) if for some reason the orchestrator does not close the trickle channel.

This would be an uncaught exception that crashes the process so just catch everything here to avoid any crashes.