### PR TITLE
live/trickle: Avoid downscaling input frames more than necessary

### DIFF
--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -178,14 +178,14 @@ class PipelineStreamer(ProcessCallbacks):
             if frame.mode != "RGBA":
                 frame = frame.convert("RGBA")
 
-            # crop the max square from the center of the image and scale to 512x512
-            # most models expect this size especially when using tensorrt
+            # Scale image to 512x512 as most models expect this size, especially when using tensorrt
             width, height = frame.size
             if (width, height) != (512, 512):
                 frame_array = np.array(frame)
 
+                # Crop to the center square if image not already square
+                square_size = min(width, height)
                 if width != height:
-                    square_size = min(width, height)
                     start_x = width // 2 - square_size // 2
                     start_y = height // 2 - square_size // 2
                     frame_array = frame_array[
@@ -193,8 +193,9 @@ class PipelineStreamer(ProcessCallbacks):
                     ]
 
                 # Resize using cv2 (much faster than PIL)
-                if frame_array.shape != (512, 512):
+                if square_size != 512:
                     frame_array = cv2.resize(frame_array, (512, 512))
+
                 frame = Image.fromarray(frame_array)
 
             logging.debug(

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -193,7 +193,8 @@ class PipelineStreamer(ProcessCallbacks):
                     ]
 
                 # Resize using cv2 (much faster than PIL)
-                frame_array = cv2.resize(frame_array, (512, 512))
+                if frame_array.shape != (512, 512):
+                    frame_array = cv2.resize(frame_array, (512, 512))
                 frame = Image.fromarray(frame_array)
 
             logging.debug(

--- a/runner/app/live/trickle/decoder.py
+++ b/runner/app/live/trickle/decoder.py
@@ -106,10 +106,10 @@ def decode_av(pipe_input, frame_callback, put_metadata):
                         next_pts_time = next_pts_time + frame_interval
 
                     h = 512
-                    w = int((512 * frame.width / frame.height) / 2) * 2
+                    w = int((512 * frame.width / frame.height) / 2) * 2 # force divisible by 2
                     if frame.height > frame.width:
                         w = 512
-                        h = int((512 * frame.height / frame.width) / 2) * 2 # force divisible by 2
+                        h = int((512 * frame.height / frame.width) / 2) * 2
                     frame = reformatter.reformat(frame, format='rgba', width=w, height=h)
                     avframe = InputFrame.from_av_video(frame)
                     avframe.log_timestamps["frame_init"] = time.time()

--- a/runner/app/live/trickle/decoder.py
+++ b/runner/app/live/trickle/decoder.py
@@ -105,11 +105,11 @@ def decode_av(pipe_input, frame_callback, put_metadata):
                         # not delayed, so use prev pts to allow more jitter
                         next_pts_time = next_pts_time + frame_interval
 
-                    w = 512
-                    h = int((512 * frame.height / frame.width) / 2) * 2 # force divisible by 2
+                    h = 512
+                    w = int((512 * frame.width / frame.height) / 2) * 2
                     if frame.height > frame.width:
-                        h = 512
-                        w = int((512 * frame.width / frame.height) / 2) * 2
+                        w = 512
+                        h = int((512 * frame.height / frame.width) / 2) * 2 # force divisible by 2
                     frame = reformatter.reformat(frame, format='rgba', width=w, height=h)
                     avframe = InputFrame.from_av_video(frame)
                     avframe.log_timestamps["frame_init"] = time.time()


### PR DESCRIPTION
We are currently resizing the input frames to 512 pixels, but we set the _lowest_ dimension
to 512. This means that we will downscale further than necessary, then crop and _upscale_
back the image on [the `streamer` side.](https://github.com/livepeer/ai-worker/blob/d06894afd00ef16eb3a09b296d56866d146f3c9d/runner/app/live/streamer/streamer.py#L196)

I tried looking around for a while to see if there was a way to crop the `VideoFrame` from within
pyav, but apparently there is not. The solution would be converting the frame to a numpy array
and cropping it there, which is exactly what we are doing on the streamer side anyway. To avoid 
duplication, I kept only the resize on the pyav decode logic, and only made sure we  don't call a
noop cv2 resize on the streamer side in case it was already resized to the right size.

If we want to go further, I think we could centralize all this frame manipulation logic on either the
decode code or the streamer code. I'll leave that for the future tho (e.g. when we want this cropping
to be parametrized).