### PR TITLE
live/streamer: Improve monitor loop reliability

### DIFF
--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -15,7 +15,6 @@ from streamer.protocol.trickle import TrickleProtocol
 from streamer.process import config_logging
 
 MAX_FILE_AGE = 86400  # 1 day
-STREAMER_INPUT_TIMEOUT = 60  # 60s
 
 # File to store the last params that a stream was started with. Used to cleanup
 # left over resources (e.g. trickle channels) left by a crashed process.
@@ -127,7 +126,6 @@ async def handle_start_stream(request: web.Request):
         )
         streamer = PipelineStreamer(
             protocol,
-            STREAMER_INPUT_TIMEOUT,
             process,
             params.request_id,
             params.stream_id,

--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -102,7 +102,8 @@ async def handle_start_stream(request: web.Request):
             # Stop the previous streamer before starting a new one
             try:
                 logging.info("Stopping previous streamer")
-                await prev_streamer.stop(timeout=10)
+                prev_streamer.trigger_stop_stream()
+                await prev_streamer.wait(timeout=10)
             except asyncio.TimeoutError as e:
                 logging.error(f"Timeout stopping streamer: {e}")
                 raise web.HTTPBadRequest(text="Timeout stopping previous streamer")

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -96,7 +96,8 @@ async def main(
         raise e
     finally:
         if streamer:
-            await streamer.stop(timeout=5)
+            streamer.trigger_stop_stream()
+            await streamer.wait(timeout=5)
         if api:
             await api.cleanup()
         await process.stop()

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -51,7 +51,6 @@ async def main(
     events_url: str,
     pipeline: str,
     params: dict,
-    input_timeout: int,
     request_id: str,
     stream_id: str,
 ):
@@ -70,9 +69,7 @@ async def main(
             protocol = ZeroMQProtocol(subscribe_url, publish_url)
         else:
             raise ValueError(f"Unsupported protocol: {stream_protocol}")
-        streamer = PipelineStreamer(
-            protocol, input_timeout, process, request_id, stream_id
-        )
+        streamer = PipelineStreamer(protocol, process, request_id, stream_id)
 
     api = None
     try:
@@ -160,12 +157,6 @@ if __name__ == "__main__":
         help="URL to publish events about pipeline status and logs.",
     )
     parser.add_argument(
-        "--input-timeout",
-        type=int,
-        default=60,
-        help="Timeout in seconds to wait after input frames stop before shutting down. Set to 0 to disable.",
-    )
-    parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose (debug) logging"
     )
     parser.add_argument(
@@ -204,7 +195,6 @@ if __name__ == "__main__":
                 events_url=args.events_url,
                 pipeline=args.pipeline,
                 params=params,
-                input_timeout=args.input_timeout,
                 request_id=args.request_id,
                 stream_id=args.stream_id,
             )

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -33,6 +33,7 @@ class PipelineProcess:
         self.error_queue = self.ctx.Queue()
         self.log_queue = self.ctx.Queue(maxsize=100)  # Keep last 100 log lines
 
+        self.pipeline_initialized = self.ctx.Event()
         self.done = self.ctx.Event()
         self.process = self.ctx.Process(target=self.process_loop, args=())
         self.start_time = 0.0
@@ -71,6 +72,9 @@ class PipelineProcess:
 
     def is_done(self):
         return self.done.is_set()
+
+    def is_pipeline_initialized(self):
+        return self.pipeline_initialized.is_set()
 
     def update_params(self, params: dict):
         self.param_update_queue.put(params)
@@ -173,6 +177,7 @@ class PipelineProcess:
 
     async def _run_pipeline_loops(self):
         pipeline = await self._initialize_pipeline()
+        self.pipeline_initialized.set()
         input_task = asyncio.create_task(self._input_loop(pipeline))
         output_task = asyncio.create_task(self._output_loop(pipeline))
         param_task = asyncio.create_task(self._param_update_loop(pipeline))

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -165,15 +165,19 @@ class PipelineProcess:
                 return pipeline
         except Exception as e:
             self._report_error(f"Error loading pipeline: {e}")
-            if params:
-                try:
-                    with log_timing(f"PipelineProcess: Pipeline loading with default params due to error with params: {params}"):
-                        pipeline = load_pipeline(self.pipeline_name)
-                        await pipeline.initialize()
-                        return pipeline
-                except Exception as e:
-                    self._report_error(f"Error loading pipeline with default params: {e}")
-                    raise
+            if not params:
+                # Already tried loading with default params
+                raise
+            try:
+                with log_timing(
+                    f"PipelineProcess: Pipeline loading with default params due to error with params: {params}"
+                ):
+                    pipeline = load_pipeline(self.pipeline_name)
+                    await pipeline.initialize()
+                    return pipeline
+            except Exception as e:
+                self._report_error(f"Error loading pipeline with default params: {e}")
+                raise
 
     async def _run_pipeline_loops(self):
         pipeline = await self._initialize_pipeline()

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -151,6 +151,10 @@ class ProcessGuardian:
             # done is only set in the middle of the restart process so also return INITIALIZING
             return PipelineState.LOADING
 
+        if self.status.state == PipelineState.ERROR:
+            # The ERROR state should be permanent, so ignore the other checks below
+            return PipelineState.ERROR
+
         # Special case: stream shutdown
         current_time = time.time()
         input = self.status.input_status

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -158,6 +158,9 @@ class ProcessGuardian:
         if self.status.inference_status.restart_count > 0:
             return PipelineState.ERROR
 
+        if self.process and not self.process.is_pipeline_initialized():
+            return PipelineState.INITIALIZING
+
         current_time = time.time()
         input = self.status.input_status
         last_input_time = input.last_input_time or self.status.start_time

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -58,7 +58,7 @@ class ProcessGuardian:
             await self.process.stop()
             self.process = None
 
-    def stop_stream(self):
+    def on_stream_stopped(self):
         self.stream_running = False
 
     async def reset_stream(

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -226,13 +226,6 @@ class ProcessGuardian:
         if not self.process:
             raise RuntimeError("Process not started")
 
-        # Restarting the process will take a couple of time, so we stop the stream
-        # before it happens so the gateway/app can switch to a functioning O ASAP.
-        logging.info(
-            f"Stopping streamer due to process restart prev_restart_count={self.status.inference_status.restart_count}"
-        )
-        self.streamer.trigger_stop_stream()
-
         # Capture logs before stopping the process
         restart_logs = self.process.get_recent_logs()
         # don't call the full start/stop methods since we only want to restart the process
@@ -288,17 +281,27 @@ class ProcessGuardian:
                     self.status.update_state(state)
 
                 if changed and state == PipelineState.ERROR:
-                    if self.status.inference_status.restart_count >= 3:
+                    restart_count = self.status.inference_status.restart_count
+                    # Restarting the process to fix the error will take a couple of time, so we also stop
+                    # the stream before it happens so the gateway/app can switch to a functioning O ASAP.
+                    logging.error(
+                        f"Pipeline is in ERROR state. Stopping streamer and restarting process. prev_restart_count={restart_count}"
+                    )
+
+                    self.streamer.trigger_stop_stream()
+
+                    if restart_count >= 3:
                         logging.error(
-                            "Pipeline process max restarts reached. Staying in ERROR state"
+                            f"Pipeline process max restarts reached, staying in ERROR state. restart_count={restart_count}"
                         )
-                        continue
-                    logging.error("Pipeline is in ERROR state. Restarting process.")
-                    # Hot fix: the comfyui pipeline process is having trouble shutting down and causes restarts not to recover.
-                    # So we skip the restart here and leave the status in ERROR so the worker will restart the whole container.
-                    logging.warning("Skipping process restart, staying in ERROR state")
-                    # TODO: Uncomment this once pipeline shutdown is fixed and restarting process is useful again.
-                    # await self._restart_process()
+                    else:
+                        # Hot fix: the comfyui pipeline process is having trouble shutting down and causes restarts not to recover.
+                        # So we skip the restart here and leave the status in ERROR so the worker will restart the whole container.
+                        logging.warning(
+                            "Skipping process restart, staying in ERROR state"
+                        )
+                        # TODO: Uncomment this once pipeline shutdown is fixed and restarting process is useful again.
+                        # await self._restart_process()
             except asyncio.CancelledError:
                 return
             except Exception:

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -82,6 +82,7 @@ class ProcessGuardian:
         self.streamer = streamer or _NoopStreamerCallbacks()
         self.process.reset_stream(request_id, stream_id)
         await self.update_params(params)
+        self.status.update_state(PipelineState.ONLINE)
 
     def send_input(self, frame: InputFrame):
         if not self.process:

--- a/runner/app/live/streamer/status.py
+++ b/runner/app/live/streamer/status.py
@@ -38,6 +38,7 @@ class InferenceStatus(BaseModel):
 
 # Use a class instead of an enum since Pydantic can't handle serializing enums
 class PipelineState:
+    INITIALIZING = "INITIALIZING"
     OFFLINE = "OFFLINE"
     ONLINE = "ONLINE"
     DEGRADED_INPUT = "DEGRADED_INPUT"

--- a/runner/app/live/streamer/status.py
+++ b/runner/app/live/streamer/status.py
@@ -56,6 +56,11 @@ class PipelineStatus(BaseModel):
     input_status: InputStatus = InputStatus()
     inference_status: InferenceStatus = InferenceStatus()
 
+    def update_state(self, state: str):
+        self.state = state
+        self.last_state_update_time = time.time()
+        return self
+
     def update_params(self, params: dict, do_update_time=True):
         self.inference_status.last_params = params
         self.inference_status.last_params_hash = hashlib.md5(json.dumps(params, sort_keys=True).encode()).hexdigest()

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -99,7 +99,7 @@ class PipelineStreamer(ProcessCallbacks):
         self.main_tasks = []
         self.auxiliary_tasks = []
         self.tasks_supervisor_task = None
-        self.process.stop_stream()
+        self.process.on_stream_stopped()
 
     async def wait(self):
         if not self.tasks_supervisor_task:

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -9,7 +9,7 @@ from asyncio import Lock
 import cv2
 from PIL import Image
 
-from .process_guardian import ProcessGuardian, ProcessCallbacks
+from .process_guardian import ProcessGuardian, StreamerCallbacks
 from .protocol.protocol import StreamProtocol
 from .status import timestamp_to_ms
 from trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutput
@@ -17,7 +17,7 @@ from trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutpu
 fps_log_interval = 10
 status_report_interval = 10
 
-class PipelineStreamer(ProcessCallbacks):
+class PipelineStreamer(StreamerCallbacks):
     def __init__(
         self,
         protocol: StreamProtocol,
@@ -97,7 +97,9 @@ class PipelineStreamer(ProcessCallbacks):
         self.main_tasks = []
         self.auxiliary_tasks = []
         self.tasks_supervisor_task = None
-        self.process.on_stream_stopped()
+
+    def is_stream_running(self) -> bool:
+        return self.tasks_supervisor_task is not None
 
     async def wait(self, *, timeout: float = 0):
         """Wait for the streamer to stop with an optional timeout. This is a blocking call."""

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -85,7 +85,7 @@ class PipelineStreamer(ProcessCallbacks):
             raise RuntimeError("Process not started")
 
         # make sure the stop event is set and give running tasks a chance to exit cleanly
-        self.stop_event.set()
+        self.trigger_stop_stream()
         _, pending = await asyncio.wait(
             self.main_tasks + self.auxiliary_tasks,
             return_when=asyncio.ALL_COMPLETED,
@@ -101,19 +101,21 @@ class PipelineStreamer(ProcessCallbacks):
         self.tasks_supervisor_task = None
         self.process.on_stream_stopped()
 
-    async def wait(self):
+    async def wait(self, *, timeout: float = 0):
+        """Wait for the streamer to stop with an optional timeout. This is a blocking call."""
         if not self.tasks_supervisor_task:
             raise RuntimeError("Streamer not started")
-        return await self.tasks_supervisor_task
+
+        awaitable: Awaitable = asyncio.shield(self.tasks_supervisor_task)
+        if timeout > 0:
+            awaitable = asyncio.wait_for(awaitable, timeout)
+        return await awaitable
 
     def is_running(self):
         return self.tasks_supervisor_task is not None
 
-    async def stop(self, *, timeout: float):
-        if not self.tasks_supervisor_task:
-            raise RuntimeError("Streamer not started")
+    def trigger_stop_stream(self):
         self.stop_event.set()
-        await asyncio.wait_for(asyncio.shield(self.tasks_supervisor_task), timeout)
 
     async def report_status_loop(self):
         next_report = time.time() + status_report_interval
@@ -138,12 +140,6 @@ class PipelineStreamer(ProcessCallbacks):
                     f"Input stream stopped for {time_since_last_input} seconds. Shutting down..."
                 )
                 self.stop_event.set()
-
-    def on_before_process_restart(self, restart_count: int) -> None:
-        # Restarting the process will take a couple of time, so we stop the stream
-        # before it happens so the gateway/app can switch to a functioning O ASAP.
-        logging.info(f"Stopping streamer due to process restart restart_count={restart_count}")
-        self.stop_event.set()
 
     async def emit_monitoring_event(self, event: dict, queue_event_type: str = "ai_stream_events"):
         """Protected method to emit monitoring event with lock"""

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -114,8 +114,11 @@ class PipelineStreamer(StreamerCallbacks):
     def is_running(self):
         return self.tasks_supervisor_task is not None
 
-    def trigger_stop_stream(self):
-        self.stop_event.set()
+    def trigger_stop_stream(self) -> bool:
+        if not self.stop_event.is_set():
+            self.stop_event.set()
+            return True
+        return False
 
     async def report_status_loop(self):
         next_report = time.time() + status_report_interval

--- a/runner/app/pipelines/base.py
+++ b/runner/app/pipelines/base.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 class HealthCheck(BaseModel):
-    status: Literal["OK", "ERROR", "IDLE"] = Field(..., description="The health status of the pipeline")
+    status: Literal["LOADING", "OK", "ERROR", "IDLE"] = Field(..., description="The health status of the pipeline")
 
 class Version(BaseModel):
     pipeline: str

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -92,7 +92,8 @@ class LiveVideoToVideoPipeline(Pipeline):
             pipe_status = PipelineStatus(**json.loads(response.read().decode()))
             return HealthCheck(
                 status=(
-                    "IDLE" if pipe_status.state == "OFFLINE"
+                    "LOADING" if pipe_status.state == "LOADING"
+                    else "IDLE" if pipe_status.state == "OFFLINE"
                     else "ERROR" if pipe_status.state == "ERROR"
                     else "OK"
                 ),


### PR DESCRIPTION
This is to rewrite the monitor logic in the process guardian/streamer both to simplify it 
as well as make it more reliable.

This implements INF-119

## Previous implementation
- Independent logic on process guardian to restart process and streamer to declare state
- Passive, state was only computed/updated when requested on healthcheck
- All the other problems described in the issue

## New implementation
- Centralized state tracking on a single place: process guardian monitor loop
- It runs every 1s and computes the current state
- When the state is ERROR, it tries restarting the process up to 3 times
   - ERROR state is sticky, until process gets restarted or container is killed
- State is updated on the status accordingly
- Shorter timeouts for errors:
   - 5s not producing output frames (after being active)
   - 30s not loading the pipeline after a simple params update
   - 120s not loading the pipeline on startup (was 240s before)

Also cleaned up other stuff along the way, like the `stream_stopped` function which can
be a `is_stream_running` callback instead so we avoid the state replication. With the new
`StreamCallbacks`, we can allow the process guardian to call the streamer for checking
state or triggering events (for now just a `stop`) with a well-defined interface to avoid 
circular references.

## Testing

Ran noop container on local box with virtual hang ups and ensure things were running smooth.