### PR TITLE
update audio-to-text pipeline and add faster-whisper backend

### DIFF
--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -65,97 +65,117 @@ class AudioToTextPipeline(Pipeline):
 
         torch_device = get_torch_device()
 
-        # Enable FlashAttention based on device compatibility.
-        attn_implementation = "eager"
-        if torch_device.type == "cuda":
-            device = torch.cuda.get_device_properties(0)
-            major, minor = device.major, device.minor
-            # FlashAttention requires CUDA Compute Capability >= 8.0.
-            if (major, minor) >= (8, 0):
-                attn_implementation = "flash_attention_2"
-            else:
-                attn_implementation = "sdpa"
-                logger.warning(
-                    f"GPU {device.name} (Compute Capability {major}.{minor}) is not "
-                    "compatible with FlashAttention, so scaled_dot_product_attention "
-                    "is being used instead."
-                )
+        self.backend = os.getenv("BACKEND", "transformers")
+        torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32
+        if self.backend == "faster-whisper":
+            from faster_whisper import WhisperModel
+            self.tm = WhisperModel(model_id, device=torch_device.type, download_root="/models")
         else:
-            logger.warning("FlashAttention disabled since it requires a CUDA device.")
+            #transformers pipeline
+            # Flash Attention does not work with word level timestamps
 
-        # Get model specific configuration parameters.
-        model_enum = ModelName.from_value(model_id)
-        self._model_cfg: ModelConfig = MODEL_CONFIGS.get(model_enum, ModelConfig())
-        kwargs["torch_dtype"] = self._model_cfg.torch_dtype
-        logger.info(
-            "AudioToText loading '%s' on device '%s' with '%s' variant",
-            model_id,
-            torch_device,
-            kwargs["torch_dtype"],
-        )
+            # Get model specific configuration parameters.
+            model_enum = ModelName.from_value(model_id)
+            self._model_cfg: ModelConfig = MODEL_CONFIGS.get(model_enum, ModelConfig())
+            kwargs["torch_dtype"] = self._model_cfg.torch_dtype
+            logger.info(
+                "AudioToText loading '%s' on device '%s' with '%s' variant",
+                model_id,
+                torch_device,
+                kwargs["torch_dtype"],
+            )
 
-        model = AutoModelForSpeechSeq2Seq.from_pretrained(
-            model_id,
-            low_cpu_mem_usage=True,
-            use_safetensors=True,
-            cache_dir=get_model_dir(),
-            attn_implementation=attn_implementation,
-            device_map="auto",
-            **kwargs,
-        )
+            model = AutoModelForSpeechSeq2Seq.from_pretrained(
+                model_id,
+                low_cpu_mem_usage=True,
+                use_safetensors=True,
+                cache_dir=get_model_dir(),
+                attn_implementation="eager",
+                device_map="auto",
+                **kwargs,
+            )
 
-        processor = AutoProcessor.from_pretrained(model_id, cache_dir=get_model_dir())
+            processor = AutoProcessor.from_pretrained(model_id, cache_dir=get_model_dir())
 
-        self.tm = pipeline(
-            "automatic-speech-recognition",
-            model=model,
-            tokenizer=processor.tokenizer,
-            feature_extractor=processor.feature_extractor,
-            max_new_tokens=128,
-            device_map="auto",
-            **kwargs,
-        )
+            self.tm = pipeline(
+                "automatic-speech-recognition",
+                model=model,
+                tokenizer=processor.tokenizer,
+                feature_extractor=processor.feature_extractor,
+                max_new_tokens=128,
+                device_map="auto",
+                **kwargs,
+            )
 
         self._audio_converter = AudioConverter()
 
     def __call__(self, audio: UploadFile, duration: float, **kwargs) -> List[File]:
-        audioBytes = audio.file.read()
-        #re-encode audio to match pre-processing done in transformers.
-        # pipeline accepts np.ndarray and does not convert it again. String file path and bytes are converted to np.ndarray in the pipeline.
-        #https://github.com/huggingface/transformers/blob/47c29ccfaf56947d845971a439cbe75a764b63d7/src/transformers/pipelines/automatic_speech_recognition.py#L353
-        #https://github.com/huggingface/transformers/blob/47c29ccfaf56947d845971a439cbe75a764b63d7/src/transformers/pipelines/audio_utils.py#L10
-        audio_array = self._audio_converter.to_ndarray(audioBytes)
-
-        # Adjust batch size and chunk length based on timestamps and duration.
-        # NOTE: Done to prevent CUDA OOM errors for large audio files.
-        kwargs["batch_size"] = self._model_cfg.batch_size
-        kwargs["chunk_length_s"] = self._model_cfg.chunk_length_s
-        if kwargs["return_timestamps"] == "word":
-            if duration > 3600:
-                raise InferenceError(
-                    f"Word timestamps are only supported for audio files up to 60 minutes for model {self.model_id}"
-                )
-            if duration > 200:
-                kwargs["batch_size"] = 4
-        if duration <= kwargs["chunk_length_s"]:
-            kwargs.pop("batch_size", None)
-            kwargs.pop("chunk_length_s", None)
-            inference_mode = "sequential"
+        if self.backend == "faster-whisper":
+            segments, info = self.tm.transcribe(audio.file, 
+                                                beam_size=5, 
+                                                word_timestamps=True if kwargs["return_timestamps"] == "word" else False)
+            text = ""
+            chunks = []
+            import time
+            start = time.time()
+            for segment in segments:
+                text += segment.text
+                if kwargs["return_timestamps"] == "word":
+                    for word in segment.words:
+                        chunks.append({
+                            "timestamp": [word.start, word.end],
+                            "text": word.word
+                        })
+                else:
+                    chunks.append({
+                        "timestamp": [segment.start,segment.end],
+                        "text": segment.text
+                    })
+                
+            logger.info(f"Transcription took {time.time()-start} seconds")
+            return {"text": text, "chunks": chunks}
         else:
-            inference_mode = f"chunked (batch_size={kwargs['batch_size']}, chunk_length_s={kwargs['chunk_length_s']})"
-        logger.info(
-            f"AudioToTextPipeline: Starting inference mode={inference_mode} with duration={duration}"
-        )
+            import time
+            start = time.time()
+            audioBytes = audio.file.read()
+            #re-encode audio to match pre-processing done in transformers.
+            # pipeline accepts np.ndarray and does not convert it again. String file path and bytes are converted to np.ndarray in the pipeline.
+            #https://github.com/huggingface/transformers/blob/47c29ccfaf56947d845971a439cbe75a764b63d7/src/transformers/pipelines/automatic_speech_recognition.py#L353
+            #https://github.com/huggingface/transformers/blob/47c29ccfaf56947d845971a439cbe75a764b63d7/src/transformers/pipelines/audio_utils.py#L10
+            audio_array = self._audio_converter.to_ndarray(audioBytes)
 
-        try:
-            outputs = self.tm(audio_array, **kwargs)
-            outputs.setdefault("chunks", [])
-        except torch.cuda.OutOfMemoryError as e:
-            raise e
-        except Exception as e:
-            raise InferenceError(original_exception=e)
+            # Adjust batch size and chunk length based on timestamps and duration.
+            # NOTE: Done to prevent CUDA OOM errors for large audio files.
+            kwargs["batch_size"] = self._model_cfg.batch_size
+            kwargs["chunk_length_s"] = self._model_cfg.chunk_length_s
+            if kwargs["return_timestamps"] == "word":
+                if duration > 3600:
+                    raise InferenceError(
+                        f"Word timestamps are only supported for audio files up to 60 minutes for model {self.model_id}"
+                    )
+                if duration > 200:
+                    kwargs["batch_size"] = 4
+            if duration <= kwargs["chunk_length_s"]:
+                kwargs.pop("batch_size", None)
+                kwargs.pop("chunk_length_s", None)
+                inference_mode = "sequential"
+            else:
+                inference_mode = f"chunked (batch_size={kwargs['batch_size']}, chunk_length_s={kwargs['chunk_length_s']})"
+            logger.info(
+                f"AudioToTextPipeline: Starting inference mode={inference_mode} with duration={duration}"
+            )
 
-        return outputs
+            try:
+                outputs = self.tm(audio_array, **kwargs)
+                outputs.setdefault("chunks", [])
+            except torch.cuda.OutOfMemoryError as e:
+                raise e
+            except Exception as e:
+                raise InferenceError(original_exception=e)
+            logger.info(
+                f"AudioToTextPipeline: Inference completed in {time.time()-start} seconds"
+            )
+            return outputs
 
     def __str__(self) -> str:
         return f"AudioToTextPipeline model_id={self.model_id}"

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -116,8 +116,6 @@ class AudioToTextPipeline(Pipeline):
                                                 word_timestamps=True if kwargs["return_timestamps"] == "word" else False)
             text = ""
             chunks = []
-            import time
-            start = time.time()
             for segment in segments:
                 text += segment.text
                 if kwargs["return_timestamps"] == "word":
@@ -132,11 +130,8 @@ class AudioToTextPipeline(Pipeline):
                         "text": segment.text
                     })
                 
-            logger.info(f"Transcription took {time.time()-start} seconds")
             return {"text": text, "chunks": chunks}
         else:
-            import time
-            start = time.time()
             audioBytes = audio.file.read()
             #re-encode audio to match pre-processing done in transformers.
             # pipeline accepts np.ndarray and does not convert it again. String file path and bytes are converted to np.ndarray in the pipeline.
@@ -172,9 +167,7 @@ class AudioToTextPipeline(Pipeline):
                 raise e
             except Exception as e:
                 raise InferenceError(original_exception=e)
-            logger.info(
-                f"AudioToTextPipeline: Inference completed in {time.time()-start} seconds"
-            )
+
             return outputs
 
     def __str__(self) -> str:

--- a/runner/app/routes/audio_to_text.py
+++ b/runner/app/routes/audio_to_text.py
@@ -89,7 +89,7 @@ def parse_return_timestamps(value: str) -> Union[bool, str]:
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def audio_to_text(
+def audio_to_text(
     audio: Annotated[
         UploadFile, File(description="Uploaded audio file to be transcribed.")
     ],

--- a/runner/docker/Dockerfile.audio_to_text
+++ b/runner/docker/Dockerfile.audio_to_text
@@ -4,17 +4,23 @@ FROM ${BASE_IMAGE}
 # Install CUDA Toolkit to enable flash attention.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    cuda-toolkit-12-1 \
+    cuda-toolkit-12-6 \
     g++ && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir \
     ninja \
-    transformers==4.43.3 \
+    transformers==4.51.3 \
     peft \
     deepcache \
-    flash_attn==2.5.6 \
     pynvml
+
+ARG VERSION="undefined"
+ENV VERSION=${VERSION}
+
+#add FASTER-WHISPER backend
+#note: ctranslate2==4.4.0 is only required if base image uses cudnnn 8
+RUN pip install faster-whisper && pip install --force-reinstall ctranslate2==4.4.0 && pip install numpy==1.26.4
 
 # Override base working directory to ensure the correct working directory.
 WORKDIR /app


### PR DESCRIPTION
This PR updates the audio-to-text backend to revert adding flash attention.  Flash Attention is not compatible with word level time stamps and we do not have a way to route audio-to-text requests to workers that are not running Flash Attention.

Updates:
- attention implementation updated to `eager`. `sdpa` attention crashed my runner.
- updates the route to `def` from `async def` to unblock health checks that if failed 3 times will cause the ai-worker to restart the container.
- added [faster-whisper](https://github.com/SYSTRAN/faster-whisper) backend from request from 10xCrazyHorse and Navigarre in streamplace discord
  - I found faster-whisper to be very stable and use less memory compare to transformers.
  - models do not work across the implementations because faster-whisper uses `ctranslate2` but the main models are available for faster-whisper
  - performance timings on 3090ti using 206 second MP4
    ```
       transcription (whisper-large-v3):
       faster-whisper  15.28s   Systran/faster-whisper-large-v3
       transformers    7.68s

       transcription (whisper-large-v3-turbo via deepdml/faster-whisper-large-v3-turbo-ct2 and deepdml/whisper-large-v3-turbo):
       faster-whisper  2.61s
       transformers    4.55s

       word level transcription (whisper-large-v3-turbo):
       faster-whisper  3.51s
       transformers    4.85s
  
       word level transcription (whisper-large-v3):
       faster-whisper  18.00s
       transformers     7.84s
    ```