### PR TITLE
fix: params revert fallback

### DIFF
--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -94,7 +94,6 @@ class ComfyUI(Pipeline):
         new_params = ComfyUIParams(**params)
         logging.info(f"Updating ComfyUI Pipeline Prompt: {new_params.prompt}")
         # TODO: currently its a single prompt, but need to support multiple prompts
-        # fallback when update fails, also only works for single prompt for now
         try:
             await self.client.update_prompts([new_params.prompt])
         except Exception as e:

--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -94,7 +94,13 @@ class ComfyUI(Pipeline):
         new_params = ComfyUIParams(**params)
         logging.info(f"Updating ComfyUI Pipeline Prompt: {new_params.prompt}")
         # TODO: currently its a single prompt, but need to support multiple prompts
-        await self.client.update_prompts([new_params.prompt])
+        # fallback when update fails, also only works for single prompt for now
+        try:
+            await self.client.update_prompts([new_params.prompt])
+        except Exception as e:
+            await self.client.set_prompts([self.params.prompt]) # reverting back to previous params
+            logging.error(f"Error updating ComfyUI Pipeline Prompt: {e}")
+            raise e
         self.params = new_params
 
     async def stop(self):

--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -98,7 +98,6 @@ class ComfyUI(Pipeline):
         try:
             await self.client.update_prompts([new_params.prompt])
         except Exception as e:
-            await self.client.set_prompts([self.params.prompt]) # reverting back to previous params
             logging.error(f"Error updating ComfyUI Pipeline Prompt: {e}")
             raise e
         self.params = new_params


### PR DESCRIPTION
PR fixes the update_params fail params state mismatch. 
if the update fails in ai-runner it automatically assumes previous params but in comfystream it needs to be updated first and then its run so there is a mismatch

comfystream fix: https://github.com/livepeer/comfystream/pull/241