### PR TITLE
add VERSION to other docker image builds and update docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 			// "dockerfile": "../docker/Dockerfile.text_to_speech",
             "dockerfile": "../runner/docker/Dockerfile.live-app__PIPELINE__",
             "args": {
-                "PIPELINE": "comfyui"
+                "PIPELINE": "comfyui",
+                "VERSION": "0.0.0-dev"
             },
             "context": "../runner"
         },

--- a/docs/runner-docker.md
+++ b/docs/runner-docker.md
@@ -22,7 +22,7 @@ To build a pipeline-specific container, you need to build the base container fir
 2. **Build the Base Container**:
 
    ```bash
-   docker build -t livepeer/ai-runner:base .
+   docker build --build-arg VERSION=$(./print_version.sh) -t livepeer/ai-runner:base .
    ```
 
    This command builds the base container and tags it as `livepeer/ai-runner:base`.
@@ -76,8 +76,8 @@ This will start the container with all necessary configurations, including GPU s
 1. Build Docker images
 ```
 export PIPELINE=noop
-docker build -t livepeer/ai-runner:live-base -f docker/Dockerfile.live-base .
-docker build -t livepeer/ai-runner:live-app-${PIPELINE} -f docker/Dockerfile.live-app-noop .
+docker build --build-arg VERSION=$(./print_version.sh) -t livepeer/ai-runner:live-base -f docker/Dockerfile.live-base .
+docker build --build-arg VERSION=$(./print_version.sh) -t livepeer/ai-runner:live-app-${PIPELINE} -f docker/Dockerfile.live-app-noop .
 ```
 
 2. Start Docker container

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -33,6 +33,9 @@ ARG PIP_VERSION=23.3.2
 RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 wheel==0.43.0 && \
   pip install --no-cache-dir torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1
 
+ARG VERSION="undefined"
+ENV VERSION=${VERSION}
+
 WORKDIR /app
 
 COPY ./requirements.txt /app

--- a/runner/dev/Dockerfile.debug
+++ b/runner/dev/Dockerfile.debug
@@ -4,6 +4,9 @@ FROM livepeer/ai-runner:base
 
 RUN pip install debugpy
 
+ARG VERSION="undefined"
+ENV VERSION=${VERSION}
+
 # Expose the debugpy port and start the app as usual.
 CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "uvicorn", "app.main:app", "--host", "", "--port", "8000"]
 

--- a/runner/dev/README.md
+++ b/runner/dev/README.md
@@ -40,7 +40,7 @@ To debug the AI runner when it operates within a container orchestrated by exter
 3. **Build the AI Runner Image**:
 
    ```bash
-   docker build -t livepeer/ai-runner:base .
+   docker build --build-arg VERSION=$(./print_version.sh) -t livepeer/ai-runner:base .
    ```
 
 4. **Build the Debug Image**:
@@ -89,7 +89,7 @@ To debug the AI runner when it operates within a container orchestrated by exter
 8. **Rebuild the Image**: Execute a rebuild of the image, ensuring to exclude the debug changes.
 
    ```bash
-   docker build -t livepeer/ai-runner:latest .
+   docker build --build-arg VERSION=$(./print_version.sh) -t livepeer/ai-runner:latest .
    ```
 
 ### Mocking the Pipelines

--- a/runner/docker/Dockerfile.llm
+++ b/runner/docker/Dockerfile.llm
@@ -33,6 +33,9 @@ ARG PIP_VERSION=24.2
 RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 wheel==0.43.0 && \
     pip install --no-cache-dir torch==2.4.0 torchvision torchaudio pip-tools
 
+ARG VERSION="undefined"
+ENV VERSION=${VERSION}
+
 WORKDIR /app
 
 COPY ./requirements.llm.in /app


### PR DESCRIPTION
@leszko here is PR to add the VERSION tag to batch pipelines docker image and updates docs to add `--build-arg VERSION=$(./print_version.sh)` to the docker build commands

Fixes https://github.com/livepeer/ai-runner/issues/594