### PR TITLE
pipelines: Bring back the native streamdiffusion pipeline

### DIFF
--- a/.github/workflows/streamdiffusion-docker.yaml
+++ b/.github/workflows/streamdiffusion-docker.yaml
@@ -1,0 +1,134 @@
+name: Build streamdiffusion ai-runner images
+
+on:
+  pull_request:
+    paths:
+      - "runner/docker/Dockerfile.live-*"
+      - "runner/app/**"
+      - "runner/images/**"
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+    paths:
+      - "runner/docker/Dockerfile.live-*"
+      - "runner/app/**"
+      - "runner/images/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ !((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
+
+jobs:
+  base:
+    name: streamdiffusion-base image
+    runs-on: [self-hosted, linux, amd64]
+    outputs:
+      image-digest: ${{ steps.build-base.outputs.digest }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for base image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: livepeer/ai-runner
+          tags: |
+            type=raw,value=live-base-streamdiffusion,enable={{is_default_branch}}
+            type=sha,prefix=live-base-streamdiffusion-sha-
+            type=sha,format=long,prefix=live-base-streamdiffusion-sha-
+            type=ref,event=pr,prefix=live-base-streamdiffusion-pr-
+            type=ref,event=tag,prefix=live-base-streamdiffusion-
+            type=ref,event=branch,prefix=live-base-streamdiffusion-
+            type=raw,value=latest,enable={{is_default_branch}},prefix=live-base-streamdiffusion-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
+      - name: Build and push live-base image
+        id: build-base
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:runner"
+          file: docker/Dockerfile.live-base-streamdiffusion
+          provenance: mode=max
+          sbom: true
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=livepeer/ai-runner:live-base-streamdiffusion-dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:live-base-streamdiffusion-dockerbuildcache,mode=max
+
+  runner:
+    name: Build pipeline image for runner
+    needs: base
+    runs-on: [self-hosted, linux, amd64]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for app image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: livepeer/ai-runner
+          tags: |
+            type=raw,value=live-app-streamdiffusion,enable={{is_default_branch}}
+            type=sha,prefix=live-app-streamdiffusion-sha-
+            type=sha,format=long,prefix=live-app-streamdiffusion-sha-
+            type=ref,event=pr,prefix=live-app-streamdiffusion-pr-
+            type=ref,event=tag,prefix=live-app-streamdiffusion-
+            type=ref,event=branch,prefix=live-app-streamdiffusion-
+            type=raw,value=latest,enable={{is_default_branch}},prefix=live-app-streamdiffusion-
+
+      - name: Get version information (for docker build tag)
+        id: version
+        run: |
+          echo "version=$(bash runner/print_version.sh)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
+      - name: Build and push pipeline app image
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:runner"
+          provenance: mode=max
+          sbom: true
+          push: true
+          file: docker/Dockerfile.live-app__PIPELINE__
+          build-args: |
+            PIPELINE=streamdiffusion
+            GIT_SHA=${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}
+            VERSION=${{ steps.version.outputs.version }}
+            # only specify base image if we just built it above, otherwise use whatever default is in the Dockerfile
+            ${{ needs.base.outputs.image-digest && format('BASE_IMAGE=livepeer/ai-runner@{0}', needs.base.outputs.image-digest) }}
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=livepeer/ai-runner:live-app-streamdiffusion-dockerbuildcache
+          cache-to: type=registry,ref=livepeer/ai-runner:live-app-streamdiffusion-dockerbuildcache,mode=max
+
+      - name: Notify new build upload
+        run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/runner/app/live/StreamDiffusionWrapper/__init__.py
+++ b/runner/app/live/StreamDiffusionWrapper/__init__.py
@@ -1,0 +1,3 @@
+from .wrapper import StreamDiffusionWrapper
+
+__all__ = ["StreamDiffusionWrapper"]

--- a/runner/app/live/StreamDiffusionWrapper/build_tensorrt.py
+++ b/runner/app/live/StreamDiffusionWrapper/build_tensorrt.py
@@ -1,0 +1,58 @@
+import argparse
+import os
+import sys
+
+# Add the current script's directory to Python path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from wrapper import StreamDiffusionWrapper
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Build TensorRT engines for StreamDiffusion")
+
+    parser.add_argument(
+        "--model-id",
+        type=str,
+        required=True,
+        help="Model ID or path to load (e.g. KBlueLeaf/kohaku-v2.1, stabilityai/sd-turbo)"
+    )
+
+    parser.add_argument(
+        "--timesteps",
+        type=int,
+        default=3,
+        help="Number of timesteps in t_index_list (default: 3)"
+    )
+
+    parser.add_argument(
+        "--engine-dir",
+        type=str,
+        default="engines",
+        help="Directory to save TensorRT engines (default: engines)"
+    )
+
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    # Create t_index_list based on number of timesteps. Only the size matters...
+    t_index_list = list(range(0, 50, 50 // args.timesteps))[:args.timesteps]
+
+    print(f"Building TensorRT engines for model: {args.model_id}")
+    print(f"Using {args.timesteps} timesteps: {t_index_list}")
+    print(f"Engines will be saved to: {args.engine_dir}")
+
+    # Initialize wrapper which will trigger already TensorRT engine building
+    wrapper = StreamDiffusionWrapper(
+        mode="img2img",
+        acceleration="tensorrt",
+        frame_buffer_size=1,
+        model_id_or_path=args.model_id,
+        t_index_list=t_index_list,
+        engine_dir=args.engine_dir
+    )
+
+    print("TensorRT engine building completed successfully!")
+
+if __name__ == "__main__":
+    main()

--- a/runner/app/live/StreamDiffusionWrapper/wrapper.py
+++ b/runner/app/live/StreamDiffusionWrapper/wrapper.py
@@ -1,0 +1,665 @@
+# Copied from StreamDiffusion/utils/wrapper.py
+
+import gc
+import os
+import traceback
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Union
+
+import numpy as np
+import torch
+from diffusers import AutoencoderTiny, StableDiffusionPipeline
+from PIL import Image
+from streamdiffusion import StreamDiffusion
+from streamdiffusion.image_utils import postprocess_image
+
+torch.set_grad_enabled(False)
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+
+
+class StreamDiffusionWrapper:
+    def __init__(
+        self,
+        model_id_or_path: str,
+        t_index_list: List[int],
+        lora_dict: Optional[Dict[str, float]] = None,
+        mode: Literal["img2img", "txt2img"] = "img2img",
+        output_type: Literal["pil", "pt", "np", "latent"] = "pil",
+        lcm_lora_id: Optional[str] = None,
+        vae_id: Optional[str] = None,
+        device: Literal["cpu", "cuda"] = "cuda",
+        dtype: torch.dtype = torch.float16,
+        frame_buffer_size: int = 1,
+        width: int = 512,
+        height: int = 512,
+        warmup: int = 10,
+        acceleration: Literal["none", "xformers", "tensorrt"] = "tensorrt",
+        do_add_noise: bool = True,
+        device_ids: Optional[List[int]] = None,
+        use_lcm_lora: bool = True,
+        use_tiny_vae: bool = True,
+        enable_similar_image_filter: bool = False,
+        similar_image_filter_threshold: float = 0.98,
+        similar_image_filter_max_skip_frame: int = 10,
+        use_denoising_batch: bool = True,
+        cfg_type: Literal["none", "full", "self", "initialize"] = "self",
+        seed: int = 2,
+        use_safety_checker: bool = False,
+        engine_dir: Optional[Union[str, Path]] = "engines",
+    ):
+        """
+        Initializes the StreamDiffusionWrapper.
+
+        Parameters
+        ----------
+        model_id_or_path : str
+            The model id or path to load.
+        t_index_list : List[int]
+            The t_index_list to use for inference.
+        lora_dict : Optional[Dict[str, float]], optional
+            The lora_dict to load, by default None.
+            Keys are the LoRA names and values are the LoRA scales.
+            Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
+        mode : Literal["img2img", "txt2img"], optional
+            txt2img or img2img, by default "img2img".
+        output_type : Literal["pil", "pt", "np", "latent"], optional
+            The output type of image, by default "pil".
+        lcm_lora_id : Optional[str], optional
+            The lcm_lora_id to load, by default None.
+            If None, the default LCM-LoRA
+            ("latent-consistency/lcm-lora-sdv1-5") will be used.
+        vae_id : Optional[str], optional
+            The vae_id to load, by default None.
+            If None, the default TinyVAE
+            ("madebyollin/taesd") will be used.
+        device : Literal["cpu", "cuda"], optional
+            The device to use for inference, by default "cuda".
+        dtype : torch.dtype, optional
+            The dtype for inference, by default torch.float16.
+        frame_buffer_size : int, optional
+            The frame buffer size for denoising batch, by default 1.
+        width : int, optional
+            The width of the image, by default 512.
+        height : int, optional
+            The height of the image, by default 512.
+        warmup : int, optional
+            The number of warmup steps to perform, by default 10.
+        acceleration : Literal["none", "xformers", "tensorrt"], optional
+            The acceleration method, by default "tensorrt".
+        do_add_noise : bool, optional
+            Whether to add noise for following denoising steps or not,
+            by default True.
+        device_ids : Optional[List[int]], optional
+            The device ids to use for DataParallel, by default None.
+        use_lcm_lora : bool, optional
+            Whether to use LCM-LoRA or not, by default True.
+        use_tiny_vae : bool, optional
+            Whether to use TinyVAE or not, by default True.
+        enable_similar_image_filter : bool, optional
+            Whether to enable similar image filter or not,
+            by default False.
+        similar_image_filter_threshold : float, optional
+            The threshold for similar image filter, by default 0.98.
+        similar_image_filter_max_skip_frame : int, optional
+            The max skip frame for similar image filter, by default 10.
+        use_denoising_batch : bool, optional
+            Whether to use denoising batch or not, by default True.
+        cfg_type : Literal["none", "full", "self", "initialize"],
+        optional
+            The cfg_type for img2img mode, by default "self".
+            You cannot use anything other than "none" for txt2img mode.
+        seed : int, optional
+            The seed, by default 2.
+        use_safety_checker : bool, optional
+            Whether to use safety checker or not, by default False.
+        """
+        self.sd_turbo = "turbo" in model_id_or_path
+
+        if mode == "txt2img":
+            if cfg_type != "none":
+                raise ValueError(
+                    f"txt2img mode accepts only cfg_type = 'none', but got {cfg_type}"
+                )
+            if use_denoising_batch and frame_buffer_size > 1:
+                if not self.sd_turbo:
+                    raise ValueError(
+                        "txt2img mode cannot use denoising batch with frame_buffer_size > 1."
+                    )
+
+        if mode == "img2img":
+            if not use_denoising_batch:
+                raise NotImplementedError(
+                    "img2img mode must use denoising batch for now."
+                )
+
+        self.device = device
+        self.dtype = dtype
+        self.width = width
+        self.height = height
+        self.mode = mode
+        self.output_type = output_type
+        self.frame_buffer_size = frame_buffer_size
+        self.batch_size = (
+            len(t_index_list) * frame_buffer_size
+            if use_denoising_batch
+            else frame_buffer_size
+        )
+
+        self.use_denoising_batch = use_denoising_batch
+        self.use_safety_checker = use_safety_checker
+
+        self.stream: StreamDiffusion = self._load_model(
+            model_id_or_path=model_id_or_path,
+            lora_dict=lora_dict,
+            lcm_lora_id=lcm_lora_id,
+            vae_id=vae_id,
+            t_index_list=t_index_list,
+            acceleration=acceleration,
+            warmup=warmup,
+            do_add_noise=do_add_noise,
+            use_lcm_lora=use_lcm_lora,
+            use_tiny_vae=use_tiny_vae,
+            cfg_type=cfg_type,
+            seed=seed,
+            engine_dir=engine_dir,
+        )
+
+        if device_ids is not None:
+            self.stream.unet = torch.nn.DataParallel(
+                self.stream.unet, device_ids=device_ids
+            )
+
+        if enable_similar_image_filter:
+            self.stream.enable_similar_image_filter(
+                similar_image_filter_threshold, similar_image_filter_max_skip_frame
+            )
+
+    def prepare(
+        self,
+        prompt: str,
+        negative_prompt: str = "",
+        num_inference_steps: int = 50,
+        guidance_scale: float = 1.2,
+        delta: float = 1.0,
+    ) -> None:
+        """
+        Prepares the model for inference.
+
+        Parameters
+        ----------
+        prompt : str
+            The prompt to generate images from.
+        num_inference_steps : int, optional
+            The number of inference steps to perform, by default 50.
+        guidance_scale : float, optional
+            The guidance scale to use, by default 1.2.
+        delta : float, optional
+            The delta multiplier of virtual residual noise,
+            by default 1.0.
+        """
+        self.stream.prepare(
+            prompt,
+            negative_prompt,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            delta=delta,
+        )
+
+    def __call__(
+        self,
+        image: Optional[Union[str, Image.Image, torch.Tensor]] = None,
+        prompt: Optional[str] = None,
+    ) -> Union[Image.Image, List[Image.Image]]:
+        """
+        Performs img2img or txt2img based on the mode.
+
+        Parameters
+        ----------
+        image : Optional[Union[str, Image.Image, torch.Tensor]]
+            The image to generate from.
+        prompt : Optional[str]
+            The prompt to generate images from.
+
+        Returns
+        -------
+        Union[Image.Image, List[Image.Image]]
+            The generated image.
+        """
+        if self.mode == "img2img":
+            return self.img2img(image, prompt)
+        else:
+            return self.txt2img(prompt)
+
+    def txt2img(
+        self, prompt: Optional[str] = None
+    ) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
+        """
+        Performs txt2img.
+
+        Parameters
+        ----------
+        prompt : Optional[str]
+            The prompt to generate images from.
+
+        Returns
+        -------
+        Union[Image.Image, List[Image.Image]]
+            The generated image.
+        """
+        if prompt is not None:
+            self.stream.update_prompt(prompt)
+
+        if self.sd_turbo:
+            image_tensor = self.stream.txt2img_sd_turbo(self.batch_size)
+        else:
+            image_tensor = self.stream.txt2img(self.frame_buffer_size)
+        image = self.postprocess_image(image_tensor, output_type=self.output_type)
+
+        if self.use_safety_checker:
+            safety_checker_input = self.feature_extractor(
+                image, return_tensors="pt"
+            ).to(self.device)
+            _, has_nsfw_concept = self.safety_checker(
+                images=image_tensor.to(self.dtype),
+                clip_input=safety_checker_input.pixel_values.to(self.dtype),
+            )
+            image = self.nsfw_fallback_img if has_nsfw_concept[0] else image
+
+        return image
+
+    def img2img(
+        self, image: Union[str, Image.Image, torch.Tensor], prompt: Optional[str] = None
+    ) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
+        """
+        Performs img2img.
+
+        Parameters
+        ----------
+        image : Union[str, Image.Image, torch.Tensor]
+            The image to generate from.
+
+        Returns
+        -------
+        Image.Image
+            The generated image.
+        """
+        if prompt is not None:
+            self.stream.update_prompt(prompt)
+
+        if isinstance(image, str) or isinstance(image, Image.Image):
+            image = self.preprocess_image(image)
+
+        image_tensor = self.stream(image)
+        image = self.postprocess_image(image_tensor, output_type=self.output_type)
+
+        if self.use_safety_checker:
+            safety_checker_input = self.feature_extractor(
+                image, return_tensors="pt"
+            ).to(self.device)
+            _, has_nsfw_concept = self.safety_checker(
+                images=image_tensor.to(self.dtype),
+                clip_input=safety_checker_input.pixel_values.to(self.dtype),
+            )
+            image = self.nsfw_fallback_img if has_nsfw_concept[0] else image
+
+        return image
+
+    def preprocess_image(self, image: Union[str, Image.Image]) -> torch.Tensor:
+        """
+        Preprocesses the image.
+
+        Parameters
+        ----------
+        image : Union[str, Image.Image, torch.Tensor]
+            The image to preprocess.
+
+        Returns
+        -------
+        torch.Tensor
+            The preprocessed image.
+        """
+        if isinstance(image, str):
+            image = Image.open(image).convert("RGB").resize((self.width, self.height))
+        if isinstance(image, Image.Image):
+            image = image.convert("RGB").resize((self.width, self.height))
+
+        return self.stream.image_processor.preprocess(
+            image, self.height, self.width
+        ).to(device=self.device, dtype=self.dtype)
+
+    def postprocess_image(
+        self, image_tensor: torch.Tensor, output_type: str = "pil"
+    ) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
+        """
+        Postprocesses the image.
+
+        Parameters
+        ----------
+        image_tensor : torch.Tensor
+            The image tensor to postprocess.
+
+        Returns
+        -------
+        Union[Image.Image, List[Image.Image]]
+            The postprocessed image.
+        """
+        if self.frame_buffer_size > 1:
+            return postprocess_image(image_tensor.cpu(), output_type=output_type)
+        else:
+            return postprocess_image(image_tensor.cpu(), output_type=output_type)[0]
+
+    def _load_model(
+        self,
+        model_id_or_path: str,
+        t_index_list: List[int],
+        lora_dict: Optional[Dict[str, float]] = None,
+        lcm_lora_id: Optional[str] = None,
+        vae_id: Optional[str] = None,
+        acceleration: Literal["none", "xformers", "tensorrt"] = "tensorrt",
+        warmup: int = 10,
+        do_add_noise: bool = True,
+        use_lcm_lora: bool = True,
+        use_tiny_vae: bool = True,
+        cfg_type: Literal["none", "full", "self", "initialize"] = "self",
+        seed: int = 2,
+        engine_dir: Optional[Union[str, Path]] = "engines",
+    ) -> StreamDiffusion:
+        """
+        Loads the model.
+
+        This method does the following:
+
+        1. Loads the model from the model_id_or_path.
+        2. Loads and fuses the LCM-LoRA model from the lcm_lora_id if needed.
+        3. Loads the VAE model from the vae_id if needed.
+        4. Enables acceleration if needed.
+        5. Prepares the model for inference.
+        6. Load the safety checker if needed.
+
+        Parameters
+        ----------
+        model_id_or_path : str
+            The model id or path to load.
+        t_index_list : List[int]
+            The t_index_list to use for inference.
+        lora_dict : Optional[Dict[str, float]], optional
+            The lora_dict to load, by default None.
+            Keys are the LoRA names and values are the LoRA scales.
+            Example: {'LoRA_1' : 0.5 , 'LoRA_2' : 0.7 ,...}
+        lcm_lora_id : Optional[str], optional
+            The lcm_lora_id to load, by default None.
+        vae_id : Optional[str], optional
+            The vae_id to load, by default None.
+        acceleration : Literal["none", "xfomers", "sfast", "tensorrt"], optional
+            The acceleration method, by default "tensorrt".
+        warmup : int, optional
+            The number of warmup steps to perform, by default 10.
+        do_add_noise : bool, optional
+            Whether to add noise for following denoising steps or not,
+            by default True.
+        use_lcm_lora : bool, optional
+            Whether to use LCM-LoRA or not, by default True.
+        use_tiny_vae : bool, optional
+            Whether to use TinyVAE or not, by default True.
+        cfg_type : Literal["none", "full", "self", "initialize"],
+        optional
+            The cfg_type for img2img mode, by default "self".
+            You cannot use anything other than "none" for txt2img mode.
+        seed : int, optional
+            The seed, by default 2.
+
+        Returns
+        -------
+        StreamDiffusion
+            The loaded model.
+        """
+
+        try:  # Load from local directory
+            pipe: StableDiffusionPipeline = StableDiffusionPipeline.from_pretrained(
+                model_id_or_path,
+            ).to(device=self.device, dtype=self.dtype)
+
+        except ValueError:  # Load from huggingface
+            pipe: StableDiffusionPipeline = StableDiffusionPipeline.from_single_file(
+                model_id_or_path,
+            ).to(device=self.device, dtype=self.dtype)
+        except Exception:  # No model found
+            traceback.print_exc()
+            print("Model load has failed. Doesn't exist.")
+            exit()
+
+        stream = StreamDiffusion(
+            pipe=pipe,
+            t_index_list=t_index_list,
+            torch_dtype=self.dtype,
+            width=self.width,
+            height=self.height,
+            do_add_noise=do_add_noise,
+            frame_buffer_size=self.frame_buffer_size,
+            use_denoising_batch=self.use_denoising_batch,
+            cfg_type=cfg_type,
+        )
+        if not self.sd_turbo:
+            if use_lcm_lora:
+                if lcm_lora_id is not None:
+                    stream.load_lcm_lora(
+                        pretrained_model_name_or_path_or_dict=lcm_lora_id
+                    )
+                else:
+                    stream.load_lcm_lora()
+                stream.fuse_lora()
+
+            if lora_dict is not None:
+                for lora_name, lora_scale in lora_dict.items():
+                    stream.load_lora(lora_name)
+                    stream.fuse_lora(lora_scale=lora_scale)
+                    print(f"Use LoRA: {lora_name} in weights {lora_scale}")
+
+        if use_tiny_vae:
+            if vae_id is not None:
+                stream.vae = AutoencoderTiny.from_pretrained(vae_id).to(
+                    device=pipe.device, dtype=pipe.dtype
+                )
+            else:
+                stream.vae = AutoencoderTiny.from_pretrained("madebyollin/taesd").to(
+                    device=pipe.device, dtype=pipe.dtype
+                )
+
+        try:
+            if acceleration == "xformers":
+                stream.pipe.enable_xformers_memory_efficient_attention()
+            if acceleration == "tensorrt":
+                from polygraphy import cuda
+                from streamdiffusion.acceleration.tensorrt import (
+                    TorchVAEEncoder,
+                    compile_unet,
+                    compile_vae_decoder,
+                    compile_vae_encoder,
+                )
+                from streamdiffusion.acceleration.tensorrt.engine import (
+                    AutoencoderKLEngine,
+                    UNet2DConditionModelEngine,
+                )
+                from streamdiffusion.acceleration.tensorrt.models import (
+                    VAE,
+                    UNet,
+                    VAEEncoder,
+                )
+
+                def create_prefix(
+                    model_id_or_path: str,
+                    max_batch_size: int,
+                    min_batch_size: int,
+                ):
+                    maybe_path = Path(model_id_or_path)
+                    if maybe_path.exists():
+                        return f"{maybe_path.stem}--lcm_lora-{use_lcm_lora}--tiny_vae-{use_tiny_vae}--max_batch-{max_batch_size}--min_batch-{min_batch_size}--mode-{self.mode}"
+                    else:
+                        return f"{model_id_or_path}--lcm_lora-{use_lcm_lora}--tiny_vae-{use_tiny_vae}--max_batch-{max_batch_size}--min_batch-{min_batch_size}--mode-{self.mode}"
+
+                engine_dir = Path(engine_dir)
+                unet_path = os.path.join(
+                    engine_dir,
+                    create_prefix(
+                        model_id_or_path=model_id_or_path,
+                        max_batch_size=stream.trt_unet_batch_size,
+                        min_batch_size=stream.trt_unet_batch_size,
+                    ),
+                    "unet.engine",
+                )
+                vae_encoder_path = os.path.join(
+                    engine_dir,
+                    create_prefix(
+                        model_id_or_path=model_id_or_path,
+                        max_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                        min_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                    ),
+                    "vae_encoder.engine",
+                )
+                vae_decoder_path = os.path.join(
+                    engine_dir,
+                    create_prefix(
+                        model_id_or_path=model_id_or_path,
+                        max_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                        min_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                    ),
+                    "vae_decoder.engine",
+                )
+
+                if not os.path.exists(unet_path):
+                    os.makedirs(os.path.dirname(unet_path), exist_ok=True)
+                    unet_model = UNet(
+                        fp16=True,
+                        device=stream.device,
+                        max_batch_size=stream.trt_unet_batch_size,
+                        min_batch_size=stream.trt_unet_batch_size,
+                        embedding_dim=stream.text_encoder.config.hidden_size,
+                        unet_dim=stream.unet.config.in_channels,
+                    )
+                    compile_unet(
+                        stream.unet,
+                        unet_model,
+                        unet_path + ".onnx",
+                        unet_path + ".opt.onnx",
+                        unet_path,
+                        opt_batch_size=stream.trt_unet_batch_size,
+                    )
+
+                if not os.path.exists(vae_decoder_path):
+                    os.makedirs(os.path.dirname(vae_decoder_path), exist_ok=True)
+                    stream.vae.forward = stream.vae.decode
+                    vae_decoder_model = VAE(
+                        device=stream.device,
+                        max_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                        min_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                    )
+                    compile_vae_decoder(
+                        stream.vae,
+                        vae_decoder_model,
+                        vae_decoder_path + ".onnx",
+                        vae_decoder_path + ".opt.onnx",
+                        vae_decoder_path,
+                        opt_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                    )
+                    delattr(stream.vae, "forward")
+
+                if not os.path.exists(vae_encoder_path):
+                    os.makedirs(os.path.dirname(vae_encoder_path), exist_ok=True)
+                    vae_encoder = TorchVAEEncoder(stream.vae).to(torch.device("cuda"))
+                    vae_encoder_model = VAEEncoder(
+                        device=stream.device,
+                        max_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                        min_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                    )
+                    compile_vae_encoder(
+                        vae_encoder,
+                        vae_encoder_model,
+                        vae_encoder_path + ".onnx",
+                        vae_encoder_path + ".opt.onnx",
+                        vae_encoder_path,
+                        opt_batch_size=self.batch_size
+                        if self.mode == "txt2img"
+                        else stream.frame_bff_size,
+                    )
+
+                cuda_stream = cuda.Stream()
+
+                vae_config = stream.vae.config
+                vae_dtype = stream.vae.dtype
+
+                stream.unet = UNet2DConditionModelEngine(
+                    unet_path, cuda_stream, use_cuda_graph=False
+                )
+                stream.vae = AutoencoderKLEngine(
+                    vae_encoder_path,
+                    vae_decoder_path,
+                    cuda_stream,
+                    stream.pipe.vae_scale_factor,
+                    use_cuda_graph=False,
+                )
+                setattr(stream.vae, "config", vae_config)
+                setattr(stream.vae, "dtype", vae_dtype)
+
+                gc.collect()
+                torch.cuda.empty_cache()
+
+                print("TensorRT acceleration enabled.")
+            if acceleration == "sfast":
+                from streamdiffusion.acceleration.sfast import (
+                    accelerate_with_stable_fast,
+                )
+
+                stream = accelerate_with_stable_fast(stream)
+                print("StableFast acceleration enabled.")
+        except Exception:
+            traceback.print_exc()
+            print("Acceleration has failed. Falling back to normal mode.")
+
+        if seed < 0:  # Random seed
+            seed = np.random.randint(0, 1000000)
+
+        stream.prepare(
+            "",
+            "",
+            num_inference_steps=50,
+            guidance_scale=1.1
+            if stream.cfg_type in ["full", "self", "initialize"]
+            else 1.0,
+            generator=torch.manual_seed(seed),
+            seed=seed,
+        )
+
+        if self.use_safety_checker:
+            from diffusers.pipelines.stable_diffusion.safety_checker import (
+                StableDiffusionSafetyChecker,
+            )
+            from transformers import CLIPFeatureExtractor
+
+            self.safety_checker = StableDiffusionSafetyChecker.from_pretrained(
+                "CompVis/stable-diffusion-safety-checker"
+            ).to(pipe.device)
+            self.feature_extractor = CLIPFeatureExtractor.from_pretrained(
+                "openai/clip-vit-base-patch32"
+            )
+            self.nsfw_fallback_img = Image.new("RGB", (512, 512), (0, 0, 0))
+
+        return stream

--- a/runner/app/live/StreamDiffusionWrapper/wrapper.py
+++ b/runner/app/live/StreamDiffusionWrapper/wrapper.py
@@ -210,7 +210,7 @@ class StreamDiffusionWrapper:
         self,
         image: Optional[Union[str, Image.Image, torch.Tensor]] = None,
         prompt: Optional[str] = None,
-    ) -> Union[Image.Image, List[Image.Image]]:
+    ) -> Union[torch.Tensor, List[torch.Tensor]]:
         """
         Performs img2img or txt2img based on the mode.
 
@@ -305,7 +305,7 @@ class StreamDiffusionWrapper:
 
         return image
 
-    def preprocess_image(self, image: Union[str, Image.Image]) -> torch.Tensor:
+    def preprocess_image(self, image: Union[str, Image.Image, torch.Tensor]) -> torch.Tensor:
         """
         Preprocesses the image.
 

--- a/runner/app/live/pipelines/interface.py
+++ b/runner/app/live/pipelines/interface.py
@@ -14,12 +14,8 @@ class Pipeline(ABC):
       exceptions propagate for optimal error reporting.
     """
 
-    def __init__(self, **params):
-        """Initialize pipeline with optional parameters.
-
-        Args:
-            **params: Parameters to initalize the pipeline with.
-        """
+    def __init__(self):
+        """Initialize pipeline with optional parameters."""
         pass
 
     @abstractmethod

--- a/runner/app/live/pipelines/loader.py
+++ b/runner/app/live/pipelines/loader.py
@@ -1,6 +1,9 @@
 from .interface import Pipeline
 
 def load_pipeline(name: str) -> Pipeline:
+    if name == "streamdiffusion":
+        from .streamdiffusion import StreamDiffusion
+        return StreamDiffusion()
     if name == "comfyui":
         from .comfyui import ComfyUI
         return ComfyUI()

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Dict, List, Literal, Optional
+
+from PIL import Image
+from pydantic import BaseModel, Field
+from StreamDiffusionWrapper import StreamDiffusionWrapper
+
+from .interface import Pipeline
+
+
+class StreamDiffusionParams(BaseModel):
+    class Config:
+        extra = "forbid"
+
+    prompt: str = "talking head, cyberpunk, tron, matrix, ultra-realistic, dark, futuristic, neon, 8k"
+    model_id: str = "KBlueLeaf/kohaku-v2.1"
+    lora_dict: Optional[Dict[str, float]] = None
+    use_lcm_lora: bool = True
+    lcm_lora_id: str = "latent-consistency/lcm-lora-sdv1-5"
+    num_inference_steps: int = 50
+    t_index_list: Optional[List[int]] = [37, 45, 48]
+    scale: float = 1.0
+    acceleration: Literal["none", "xformers", "tensorrt"] = "tensorrt"
+    use_denoising_batch: bool = True
+    enable_similar_image_filter: bool = False
+    seed: int = 2
+    guidance_scale: float = 1.2
+    do_add_noise: bool = False
+    similar_image_filter_threshold: float = 0.98
+
+
+class StreamDiffusion(Pipeline):
+    def __init__(self, **params):
+        super().__init__(**params)
+        self.pipe: Optional[StreamDiffusionWrapper] = None
+        self.first_frame = True
+        self.update_params(**params)
+
+    def process_frame(self, image: Image.Image) -> Image.Image:
+        img_tensor = self.pipe.preprocess_image(image)
+        img_tensor = self.pipe.stream.image_processor.denormalize(img_tensor)
+
+        if self.first_frame:
+            self.first_frame = False
+            for _ in range(self.pipe.batch_size):
+                self.pipe(image=img_tensor)
+
+        return self.pipe(image=img_tensor)
+
+    def update_params(self, **params):
+        new_params = StreamDiffusionParams(**params)
+        if self.pipe is not None:
+            # avoid resetting the pipe if only the prompt changed
+            only_prompt = self.params.model_copy(update={"prompt": new_params.prompt})
+            if new_params == only_prompt:
+                logging.info(f"Updating prompt: {new_params.prompt}")
+                self.pipe.stream.update_prompt(new_params.prompt)
+                self.params = new_params
+                return
+
+        logging.info(f"Resetting diffuser for params change")
+        pipe = StreamDiffusionWrapper(
+            model_id_or_path=new_params.model_id,
+            lora_dict=new_params.lora_dict,
+            use_lcm_lora=new_params.use_lcm_lora,
+            lcm_lora_id=new_params.lcm_lora_id,
+            t_index_list=new_params.t_index_list,
+            frame_buffer_size=1,
+            width=512,
+            height=512,
+            warmup=10,
+            acceleration=new_params.acceleration,
+            do_add_noise=new_params.do_add_noise,
+            mode="img2img",
+            # output_type="pt",
+            enable_similar_image_filter=new_params.enable_similar_image_filter,
+            similar_image_filter_threshold=new_params.similar_image_filter_threshold,
+            use_denoising_batch=new_params.use_denoising_batch,
+            seed=new_params.seed,
+        )
+        pipe.prepare(
+            prompt=new_params.prompt,
+            num_inference_steps=new_params.num_inference_steps,
+            guidance_scale=new_params.guidance_scale,
+        )
+
+        self.params = new_params
+        self.pipe = pipe
+        self.first_frame = True

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -83,7 +83,7 @@ class StreamDiffusion(Pipeline):
             lora_dict=new_params.lora_dict,
             use_lcm_lora=new_params.use_lcm_lora,
             lcm_lora_id=new_params.lcm_lora_id,
-            t_index_list=new_params.t_index_list
+            t_index_list=new_params.t_index_list,
             frame_buffer_size=1,
             width=512,
             height=512,

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -1,9 +1,9 @@
 import logging
 import asyncio
-from typing import Dict, List, Literal, Optional, cast
+from typing import Dict, List, Literal, Optional
 
-from PIL import Image
-from pydantic import BaseModel, Field
+import torch
+from pydantic import BaseModel
 from StreamDiffusionWrapper import StreamDiffusionWrapper
 
 from .interface import Pipeline
@@ -44,29 +44,31 @@ class StreamDiffusion(Pipeline):
         logging.info("Pipeline initialization complete")
 
     async def put_video_frame(self, frame: VideoFrame, request_id: str):
+        out_tensor = await asyncio.to_thread(self.process_tensor_sync, frame.tensor)
+        output = VideoOutput(frame, request_id).replace_tensor(out_tensor)
+        await self.frame_queue.put(output)
+
+    def process_tensor_sync(self, img_tensor: torch.Tensor):
         if self.pipe is None:
             raise RuntimeError("Pipeline not initialized")
 
         # The incoming frame.tensor is (B, H, W, C) in range [-1, 1] while the
         # VaeImageProcessor inside the wrapper expects (B, C, H, W) in [0, 1].
-        img_tensor = frame.tensor.permute(0, 3, 1, 2)
+        img_tensor = img_tensor.permute(0, 3, 1, 2)
         img_tensor = self.pipe.stream.image_processor.denormalize(img_tensor)
         img_tensor = self.pipe.preprocess_image(img_tensor)
 
         if self.first_frame:
             self.first_frame = False
             for _ in range(self.pipe.batch_size):
-                _ = await asyncio.to_thread(self.pipe, image=img_tensor)
+                self.pipe(image=img_tensor)
 
-        out_tensor = await asyncio.to_thread(self.pipe, image=img_tensor)
+        out_tensor = self.pipe(image=img_tensor)
         if isinstance(out_tensor, list):
             out_tensor = out_tensor[0]
 
         # The output tensor from the wrapper is (C, H, W), and the encoder expects (1, H, W, C).
-        out_tensor = out_tensor.permute(1, 2, 0).unsqueeze(0)
-
-        output = VideoOutput(frame, request_id).replace_tensor(out_tensor)
-        await self.frame_queue.put(output)
+        return out_tensor.permute(1, 2, 0).unsqueeze(0)
 
     async def get_processed_video_frame(self) -> VideoOutput:
         return await self.frame_queue.get()
@@ -83,37 +85,39 @@ class StreamDiffusion(Pipeline):
                 return
 
         logging.info(f"Resetting diffuser for params change")
-        def load_streamdiffusion():
-            pipe = StreamDiffusionWrapper(
-                output_type="pt",
-                model_id_or_path=new_params.model_id,
-                lora_dict=new_params.lora_dict,
-                use_lcm_lora=new_params.use_lcm_lora,
-                lcm_lora_id=new_params.lcm_lora_id,
-                t_index_list=new_params.t_index_list,
-                frame_buffer_size=1,
-                width=512,
-                height=512,
-                warmup=10,
-                acceleration=new_params.acceleration,
-                do_add_noise=new_params.do_add_noise,
-                mode="img2img",
-                enable_similar_image_filter=new_params.enable_similar_image_filter,
-                similar_image_filter_threshold=new_params.similar_image_filter_threshold,
-                use_denoising_batch=new_params.use_denoising_batch,
-                seed=new_params.seed,
-            )
-            pipe.prepare(
-                prompt=new_params.prompt,
-                num_inference_steps=new_params.num_inference_steps,
-                guidance_scale=new_params.guidance_scale,
-            )
-            return pipe
 
-        self.pipe = await asyncio.to_thread(load_streamdiffusion)
+        self.pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
         self.params = new_params
         self.first_frame = True
 
     async def stop(self):
         logging.info("Stopping StreamDiffusion pipeline")
         self.pipe = None
+
+
+def load_streamdiffusion_sync(params: StreamDiffusionParams):
+    pipe = StreamDiffusionWrapper(
+        output_type="pt",
+        model_id_or_path=params.model_id,
+        lora_dict=params.lora_dict,
+        use_lcm_lora=params.use_lcm_lora,
+        lcm_lora_id=params.lcm_lora_id,
+        t_index_list=params.t_index_list,
+        frame_buffer_size=1,
+        width=512,
+        height=512,
+        warmup=10,
+        acceleration=params.acceleration,
+        do_add_noise=params.do_add_noise,
+        mode="img2img",
+        enable_similar_image_filter=params.enable_similar_image_filter,
+        similar_image_filter_threshold=params.similar_image_filter_threshold,
+        use_denoising_batch=params.use_denoising_batch,
+        seed=params.seed,
+    )
+    pipe.prepare(
+        prompt=params.prompt,
+        num_inference_steps=params.num_inference_steps,
+        guidance_scale=params.guidance_scale,
+    )
+    return pipe

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -77,33 +77,35 @@ class StreamDiffusion(Pipeline):
                 return
 
         logging.info(f"Resetting diffuser for params change")
-        pipe = StreamDiffusionWrapper(
-            output_type="pt",
-            model_id_or_path=new_params.model_id,
-            lora_dict=new_params.lora_dict,
-            use_lcm_lora=new_params.use_lcm_lora,
-            lcm_lora_id=new_params.lcm_lora_id,
-            t_index_list=new_params.t_index_list,
-            frame_buffer_size=1,
-            width=512,
-            height=512,
-            warmup=10,
-            acceleration=new_params.acceleration,
-            do_add_noise=new_params.do_add_noise,
-            mode="img2img",
-            enable_similar_image_filter=new_params.enable_similar_image_filter,
-            similar_image_filter_threshold=new_params.similar_image_filter_threshold,
-            use_denoising_batch=new_params.use_denoising_batch,
-            seed=new_params.seed,
-        )
-        pipe.prepare(
-            prompt=new_params.prompt,
-            num_inference_steps=new_params.num_inference_steps,
-            guidance_scale=new_params.guidance_scale,
-        )
+        def load_streamdiffusion():
+            pipe = StreamDiffusionWrapper(
+                output_type="pt",
+                model_id_or_path=new_params.model_id,
+                lora_dict=new_params.lora_dict,
+                use_lcm_lora=new_params.use_lcm_lora,
+                lcm_lora_id=new_params.lcm_lora_id,
+                t_index_list=new_params.t_index_list,
+                frame_buffer_size=1,
+                width=512,
+                height=512,
+                warmup=10,
+                acceleration=new_params.acceleration,
+                do_add_noise=new_params.do_add_noise,
+                mode="img2img",
+                enable_similar_image_filter=new_params.enable_similar_image_filter,
+                similar_image_filter_threshold=new_params.similar_image_filter_threshold,
+                use_denoising_batch=new_params.use_denoising_batch,
+                seed=new_params.seed,
+            )
+            pipe.prepare(
+                prompt=new_params.prompt,
+                num_inference_steps=new_params.num_inference_steps,
+                guidance_scale=new_params.guidance_scale,
+            )
+            return pipe
 
+        self.pipe = await asyncio.to_thread(load_streamdiffusion)
         self.params = new_params
-        self.pipe = pipe
         self.first_frame = True
 
     async def stop(self):

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -315,6 +315,9 @@ class QueueTeeStream:
     def flush(self):
         self.original_stream.flush()
 
+    def isatty(self):
+        return self.original_stream.isatty()
+
 class LogQueueHandler(logging.Handler):
     """Send all log records to the process's log queue"""
     def __init__(self, process: PipelineProcess):

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -3,6 +3,7 @@
 [ -v DEBUG ] && set -x
 
 # ComfyUI image configuration
+PULL_IMAGES=${PULL_IMAGES:-true}
 AI_RUNNER_COMFYUI_IMAGE=${AI_RUNNER_COMFYUI_IMAGE:-livepeer/ai-runner:live-app-comfyui}
 AI_RUNNER_STREAMDIFFUSION_IMAGE=${AI_RUNNER_STREAMDIFFUSION_IMAGE:-livepeer/ai-runner:live-app-streamdiffusion}
 CONDA_PYTHON="/workspace/miniconda3/envs/comfystream/bin/python"
@@ -97,7 +98,9 @@ function download_live_models() {
   huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 
   # ComfyUI
-  docker pull "${AI_RUNNER_COMFYUI_IMAGE}"
+  if [ "$PULL_IMAGES" = true ]; then
+    docker pull "${AI_RUNNER_COMFYUI_IMAGE}"
+  fi
 
   # ComfyUI models
   if ! docker image inspect $AI_RUNNER_COMFYUI_IMAGE >/dev/null 2>&1; then
@@ -129,7 +132,9 @@ function build_tensorrt_models() {
 
 
   # StreamDiffusion (compile a matrix of models and timesteps)
-  # docker pull $AI_RUNNER_STREAMDIFFUSION_IMAGE
+  if [ "$PULL_IMAGES" = true ]; then
+    docker pull $AI_RUNNER_STREAMDIFFUSION_IMAGE
+  fi
   # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
   docker image tag $AI_RUNNER_STREAMDIFFUSION_IMAGE livepeer/ai-runner:live-app-streamdiffusion
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -239,7 +239,7 @@ done
 
 echo "Starting livepeer AI subnet model downloader..."
 echo "Creating 'models' directory in the current working directory..."
-mkdir -p models/checkpoints models/ComfyUI--{models,output}
+mkdir -p models/checkpoints models/StreamDiffusion--engines models/ComfyUI--{models,output}
 
 # Ensure 'huggingface-cli' is installed.
 echo "Checking if 'huggingface-cli' is installed..."

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -144,7 +144,7 @@ function build_tensorrt_models() {
       bash -c "for model in $MODELS; do
                   for timestep in $TIMESTEPS; do
                       echo \"Building TensorRT engines for model=\$model timestep=\$timestep...\" && \
-                      python app/live/StreamDiffusionWrapper/build_tensorrt.py --model-id \$model --timesteps \$timestep
+                      $CONDA_PYTHON app/live/StreamDiffusionWrapper/build_tensorrt.py --model-id \$model --timesteps \$timestep
                   done
               done
               adduser $(id -u -n)

--- a/runner/docker/Dockerfile.live-app__PIPELINE__
+++ b/runner/docker/Dockerfile.live-app__PIPELINE__
@@ -1,4 +1,4 @@
-ARG PIPELINE=streamdiffusion
+ARG PIPELINE=comfyui
 ARG BASE_IMAGE=livepeer/ai-runner:live-base-${PIPELINE}
 FROM ${BASE_IMAGE}
 ARG PIPELINE

--- a/runner/docker/Dockerfile.live-app__PIPELINE__
+++ b/runner/docker/Dockerfile.live-app__PIPELINE__
@@ -1,4 +1,4 @@
-ARG PIPELINE=comfyui
+ARG PIPELINE=streamdiffusion
 ARG BASE_IMAGE=livepeer/ai-runner:live-base-${PIPELINE}
 FROM ${BASE_IMAGE}
 ARG PIPELINE

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=livepeer/ai-runner:live-base
+FROM ${BASE_IMAGE}
+
+# Install required Python version
+ARG PYTHON_VERSION=3.10
+RUN pyenv install $PYTHON_VERSION && \
+    pyenv global $PYTHON_VERSION && \
+    pyenv rehash
+
+# Upgrade pip and install required packages
+ARG PIP_VERSION=23.3.2
+ENV PIP_PREFER_BINARY=1
+RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 wheel==0.43.0
+
+# Install StreamDiffusion dependencies
+RUN pip install --no-cache-dir \
+    torch==2.1.0 \
+    torchvision==0.16.0 \
+    xformers===0.0.22.post7 \
+    --index-url https://download.pytorch.org/whl/cu121
+
+# Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
+RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
+
+# Install TensorRT extension (requires huggingface-hub)
+RUN pip install --no-cache-dir huggingface-hub==0.24.0 && \
+    python -m streamdiffusion.tools.install-tensorrt
+
+WORKDIR /app
+
+# Create symlink for where StreamDiffusion builds TensorRT engines at runtime
+RUN ln -s /models/StreamDiffusion--engines ./engines

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -1,33 +1,42 @@
 ARG BASE_IMAGE=livepeer/ai-runner:live-base
 FROM ${BASE_IMAGE}
 
-# Install required Python version
+# Install Miniconda and create the 'comfystream' environment
 ARG PYTHON_VERSION=3.10
-RUN pyenv install $PYTHON_VERSION && \
-    pyenv global $PYTHON_VERSION && \
-    pyenv rehash
+ENV CONDA_DIR /workspace/miniconda3
+ENV PATH $CONDA_DIR/bin:$PATH
 
-# Upgrade pip and install required packages
-ARG PIP_VERSION=23.3.2
+RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-certificates && \
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p $CONDA_DIR && \
+    rm ~/miniconda.sh && \
+    conda init bash && \
+    conda config --set auto_activate_base false && \
+    conda clean -a -y && \
+    conda create -n comfystream python=$PYTHON_VERSION -y && \
+    conda run -n comfystream pip install --no-cache-dir --upgrade pip==23.3.2 setuptools==69.5.1 wheel==0.43.0 && \
+    conda clean -a -y && \
+    apt-get purge -y --auto-remove wget curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENV PIP_PREFER_BINARY=1
-RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 wheel==0.43.0
 
-# Install StreamDiffusion dependencies
-RUN pip install --no-cache-dir \
+# Install StreamDiffusion dependencies into the comfystream environment
+RUN conda run -n comfystream pip install --no-cache-dir \
     torch==2.1.0 \
     torchvision==0.16.0 \
     xformers===0.0.22.post7 \
     --index-url https://download.pytorch.org/whl/cu121
 
-# Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
-RUN pip install git+https://github.com/pschroedl/StreamDiffusion.git@f882db2#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ f882db2 (latest at time of writing) into the comfystream environment
+RUN conda run -n comfystream pip install --no-cache-dir git+https://github.com/pschroedl/StreamDiffusion.git@f882db2#egg=streamdiffusion[tensorrt]
 
-# Install TensorRT extension and ensure compatible dependencies
-RUN pip install --no-cache-dir --force-reinstall \
+# Install TensorRT extension and ensure compatible dependencies into the comfystream environment
+RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
     huggingface-hub==0.22.0 \
     diffusers==0.27.2 \
     transformers==4.38.2
-RUN python -m streamdiffusion.tools.install-tensorrt
+RUN conda run -n comfystream python -m streamdiffusion.tools.install-tensorrt
 
 WORKDIR /app
 

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -20,11 +20,14 @@ RUN pip install --no-cache-dir \
     --index-url https://download.pytorch.org/whl/cu121
 
 # Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
-RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
+RUN pip install git+https://github.com/pschroedl/StreamDiffusion.git@f882db2#egg=streamdiffusion[tensorrt]
 
-# Install TensorRT extension (requires huggingface-hub)
-RUN pip install --no-cache-dir huggingface-hub==0.24.0 && \
-    python -m streamdiffusion.tools.install-tensorrt
+# Install TensorRT extension and ensure compatible dependencies
+RUN pip install --no-cache-dir --force-reinstall \
+    huggingface-hub==0.22.0 \
+    diffusers==0.27.2 \
+    transformers==4.38.2
+RUN python -m streamdiffusion.tools.install-tensorrt
 
 WORKDIR /app
 

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -28,13 +28,12 @@ RUN conda run -n comfystream pip install --no-cache-dir \
     xformers===0.0.22.post7 \
     --index-url https://download.pytorch.org/whl/cu121
 
-# Install StreamDiffusion @ f882db2 (latest at time of writing) into the comfystream environment
-RUN conda run -n comfystream pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ b623251 (latest at time of writing) into the comfystream environment
+RUN conda run -n comfystream pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@b623251#egg=streamdiffusion[tensorrt]
 
 # Install TensorRT extension and ensure compatible dependencies into the comfystream environment
 RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
-    huggingface-hub==0.22.0 \
-    diffusers==0.24.0 \
+    huggingface-hub==0.25.2 \
     transformers==4.38.2
 RUN conda run -n comfystream python -m streamdiffusion.tools.install-tensorrt
 

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -29,12 +29,12 @@ RUN conda run -n comfystream pip install --no-cache-dir \
     --index-url https://download.pytorch.org/whl/cu121
 
 # Install StreamDiffusion @ f882db2 (latest at time of writing) into the comfystream environment
-RUN conda run -n comfystream pip install --no-cache-dir git+https://github.com/pschroedl/StreamDiffusion.git@f882db2#egg=streamdiffusion[tensorrt]
+RUN conda run -n comfystream pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
 
 # Install TensorRT extension and ensure compatible dependencies into the comfystream environment
 RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
     huggingface-hub==0.22.0 \
-    diffusers==0.27.2 \
+    diffusers==0.24.0 \
     transformers==4.38.2
 RUN conda run -n comfystream python -m streamdiffusion.tools.install-tensorrt
 

--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -12,3 +12,4 @@ nvidia-ml-py==12.560.30
 pynvml==12.0.0
 opencv-python==4.10.0.84
 av==14.4.0
+peft==0.11.1

--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -10,3 +10,5 @@ watchdog==5.0.2
 prometheus_client==0.21.1
 nvidia-ml-py==12.560.30
 pynvml==12.0.0
+opencv-python==4.10.0.84
+av==14.4.0


### PR DESCRIPTION
This is to bring back the `streamdiffusion` pipeline that had been removed on #461.

The process was mainly to revert the relevant changes and then adjust any interface that changed
so it works on the new world. We have actually made several improvements to the pipeline since then
and this works much more performant than before.

**On my dev server, the comfystream pipeline performs 21 FPS while this works at 40 FPS.**

Use the box to test this: https://github.com/livepeer/go-livepeer/pull/3602