### PR TITLE
update comfyui-base to fix engine compilation

### DIFF
--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=livepeer/comfyui-base@sha256:21ac5eb58c93d8b76514f23119e7a4f997db8bc5a89d3718e43cccde6195eb3d
+ARG BASE_IMAGE=livepeer/comfyui-base@sha256:c920d5c37b5808889109d41a58ce44eea927a0c1c89d59090727833e5b576a4b
 FROM ${BASE_IMAGE}
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This change bumps livepeer/comfyui-base to downgrade onnxruntiume from 1.22.0 to 1.17.0 to resolve an issue with engine compilation. The prior image tag was still outdated in https://github.com/livepeer/ai-runner/pull/611

Current image
![image](https://github.com/user-attachments/assets/22a04726-8f4e-4597-a8e9-22fe5bb27efd)

New image
![image](https://github.com/user-attachments/assets/8b681b1f-8bc2-4fd9-a703-ad921ea3e8cb)

