### PR TITLE
streamdiffusion: Add controlnet support

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -64,10 +64,37 @@ class StreamDiffusionParams(BaseModel):
     # ControlNet settings
     controlnets: Optional[List[ControlNetConfig]] = [
         ControlNetConfig(
+            model_id="lllyasviel/control_v11f1p_sd15_depth",
+            conditioning_scale=0.28,
+            preprocessor="depth_tensorrt",
+            preprocessor_params={
+                "engine_path": "./engines/depth-anything/depth_anything_v2_vits.engine",
+                "detect_resolution": 518,
+                "image_resolution": 512
+            },
+            enabled=True,
+            control_guidance_start=0.0,
+            control_guidance_end=1.0,
+        ),
+        ControlNetConfig(
             model_id="lllyasviel/control_v11f1e_sd15_tile",
             conditioning_scale=0.2,
             preprocessor="passthrough",
             preprocessor_params={"image_resolution": 512},
+            enabled=True,
+            control_guidance_start=0.0,
+            control_guidance_end=1.0,
+        ),
+        ControlNetConfig(
+            model_id="lllyasviel/`control_v11p_sd15_lineart`",
+            conditioning_scale=0.0,
+            preprocessor="standard_lineart",
+            preprocessor_params={
+                "detect_resolution": 512,
+                "image_resolution": 512,
+                "gaussian_sigma": 6.0,
+                "intensity_threshold": 8
+            },
             enabled=True,
             control_guidance_start=0.0,
             control_guidance_end=1.0,

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -77,6 +77,18 @@ class StreamDiffusionParams(BaseModel):
             control_guidance_end=1.0,
         ),
         ControlNetConfig(
+            model_id="lllyasviel/control_v11p_sd15_canny",
+            conditioning_scale=0.29,
+            preprocessor="canny",
+            preprocessor_params={
+                "low_threshold": 100,
+                "high_threshold": 200
+            },
+            enabled=True,
+            control_guidance_start=0.0,
+            control_guidance_end=1.0,
+        ),
+        ControlNetConfig(
             model_id="lllyasviel/control_v11f1e_sd15_tile",
             conditioning_scale=0.2,
             preprocessor="passthrough",

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -1,6 +1,7 @@
 import logging
 import asyncio
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union, Any
+from pathlib import Path
 
 import torch
 from pydantic import BaseModel
@@ -11,27 +12,81 @@ from trickle import VideoFrame, VideoOutput
 from trickle import DEFAULT_WIDTH, DEFAULT_HEIGHT
 
 
+class ControlNetConfig(BaseModel):
+    """ControlNet configuration model"""
+    model_id: str
+    conditioning_scale: float = 1.0
+    preprocessor: Optional[str] = None
+    preprocessor_params: Optional[Dict[str, Any]] = None
+    enabled: bool = True
+    control_guidance_start: float = 0.0
+    control_guidance_end: float = 1.0
+
+
 class StreamDiffusionParams(BaseModel):
     class Config:
         extra = "forbid"
 
-    prompt: str = "talking head, cyberpunk, tron, matrix, ultra-realistic, dark, futuristic, neon, 8k"
+    # Model configuration
     model_id: str = "KBlueLeaf/kohaku-v2.1"
+    pipeline_type: str = "sd1.5"
+
+    # Generation parameters
+    prompt: str = "an anime render of a girl with purple hair, masterpiece"
+    negative_prompt: str = "blurry, low quality, flat, 2d"
+    guidance_scale: float = 1.1
+    num_inference_steps: int = 50
+    delta: float = 0.7
+
+    # Image dimensions
     width: int = DEFAULT_WIDTH
     height: int = DEFAULT_HEIGHT
+
+    # Model settings
+    device: str = "cuda"
+    dtype: str = "float16"
+    t_index_list: List[int] = [0, 16, 32]
+    frame_buffer_size: int = 1
+
+    # LoRA settings
     lora_dict: Optional[Dict[str, float]] = None
     use_lcm_lora: bool = True
     lcm_lora_id: str = "latent-consistency/lcm-lora-sdv1-5"
-    num_inference_steps: int = 50
-    t_index_list: List[int] = [37, 45, 48]
-    scale: float = 1.0
+
+    # VAE settings
+    use_tiny_vae: bool = True
+    vae_id: Optional[str] = None
+
+    # Acceleration settings
     acceleration: Literal["none", "xformers", "tensorrt"] = "tensorrt"
+
+    # Processing settings
     use_denoising_batch: bool = True
+    do_add_noise: bool = True
+    cfg_type: Literal["none", "full", "self", "initialize"] = "self"
+    seed: int = 789
+
+    # Image filter settings
     enable_similar_image_filter: bool = False
-    seed: int = 2
-    guidance_scale: float = 1.2
-    do_add_noise: bool = False
     similar_image_filter_threshold: float = 0.98
+    similar_image_filter_max_skip_frame: int = 10
+
+    # Safety settings
+    use_safety_checker: bool = False
+
+    # ControlNet settings
+    use_controlnet: bool = True
+    controlnets: Optional[List[ControlNetConfig]] = [
+        ControlNetConfig(
+            model_id="lllyasviel/control_v11f1e_sd15_tile",
+            conditioning_scale=0.2,
+            preprocessor="passthrough",
+            preprocessor_params={"image_resolution": 512},
+            enabled=True,
+            control_guidance_start=0.0,
+            control_guidance_end=1.0,
+        )
+    ]
 
 
 class StreamDiffusion(Pipeline):
@@ -63,7 +118,9 @@ class StreamDiffusion(Pipeline):
         img_tensor = self.pipe.stream.image_processor.denormalize(img_tensor)
         img_tensor = self.pipe.preprocess_image(img_tensor)
 
-        self.pipe.update_control_image_efficient(img_tensor)
+        # Update control image if using ControlNet
+        if self.params.use_controlnet:
+            self.pipe.update_control_image_efficient(img_tensor)
 
         if self.first_frame:
             self.first_frame = False
@@ -104,30 +161,81 @@ class StreamDiffusion(Pipeline):
             self.frame_queue = asyncio.Queue()
 
 
-def load_streamdiffusion_sync(params: StreamDiffusionParams):
+def _parse_dtype(dtype_str: str) -> torch.dtype:
+    """Parse dtype string to torch dtype"""
+    dtype_map = {
+        'float16': torch.float16,
+        'float32': torch.float32,
+        'half': torch.float16,
+        'float': torch.float32,
+    }
+    return dtype_map.get(dtype_str.lower(), torch.float16)
+
+
+def _prepare_controlnet_configs(params: StreamDiffusionParams) -> Optional[List[Dict[str, Any]]]:
+    """Prepare ControlNet configurations for wrapper"""
+    if not params.use_controlnet or not params.controlnets:
+        return None
+
+    controlnet_configs = []
+    for cn_config in params.controlnets:
+        if not cn_config.enabled:
+            continue
+
+        controlnet_config = {
+            'model_id': cn_config.model_id,
+            'preprocessor': cn_config.preprocessor,
+            'conditioning_scale': cn_config.conditioning_scale,
+            'enabled': cn_config.enabled,
+            'preprocessor_params': cn_config.preprocessor_params or {},
+            'pipeline_type': params.pipeline_type,
+            'control_guidance_start': cn_config.control_guidance_start,
+            'control_guidance_end': cn_config.control_guidance_end,
+        }
+        controlnet_configs.append(controlnet_config)
+
+    return controlnet_configs
+
+
+def load_streamdiffusion_sync(params: StreamDiffusionParams, build_engines_if_missing: bool = False):
+    # Prepare ControlNet configuration
+    controlnet_config = _prepare_controlnet_configs(params)
+
     pipe = StreamDiffusionWrapper(
-        output_type="pt",
         model_id_or_path=params.model_id,
-        lora_dict=params.lora_dict,
-        use_lcm_lora=params.use_lcm_lora,
-        lcm_lora_id=params.lcm_lora_id,
         t_index_list=params.t_index_list,
-        frame_buffer_size=1,
+        lora_dict=params.lora_dict,
+        mode="img2img",
+        output_type="pt",
+        lcm_lora_id=params.lcm_lora_id,
+        vae_id=params.vae_id,
+        device=params.device,
+        dtype=_parse_dtype(params.dtype),
+        frame_buffer_size=params.frame_buffer_size,
         width=params.width,
         height=params.height,
         warmup=10,
         acceleration=params.acceleration,
         do_add_noise=params.do_add_noise,
-        mode="img2img",
+        use_lcm_lora=params.use_lcm_lora,
+        use_tiny_vae=params.use_tiny_vae,
         enable_similar_image_filter=params.enable_similar_image_filter,
         similar_image_filter_threshold=params.similar_image_filter_threshold,
+        similar_image_filter_max_skip_frame=params.similar_image_filter_max_skip_frame,
         use_denoising_batch=params.use_denoising_batch,
+        cfg_type=params.cfg_type,
         seed=params.seed,
-        build_engines_if_missing=False,
+        use_safety_checker=params.use_safety_checker,
+        build_engines_if_missing=build_engines_if_missing,
+        use_controlnet=params.use_controlnet,
+        controlnet_config=controlnet_config,
     )
+
     pipe.prepare(
         prompt=params.prompt,
+        negative_prompt=params.negative_prompt,
         num_inference_steps=params.num_inference_steps,
         guidance_scale=params.guidance_scale,
+        delta=params.delta,
     )
     return pipe

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -1,6 +1,27 @@
 import argparse
+from typing import Dict, List, Any
 
 from streamdiffusion import StreamDiffusionWrapper
+
+def create_controlnet_configs(controlnet_model_ids: List[str], image_resolution: int = 512) -> List[Dict[str, Any]]:
+    """Create dummy ControlNet configurations for compilation"""
+    controlnet_configs = []
+
+    for model_id in controlnet_model_ids:
+        # Create a basic configuration for each ControlNet
+        # The exact parameters don't matter for compilation, just need the model to be loaded
+        config = {
+            'model_id': model_id,
+            'conditioning_scale': 0.5,  # Default scale
+            'preprocessor': "passthrough",  # Simple preprocessor
+            'preprocessor_params': {"image_resolution": image_resolution},
+            'enabled': True,
+            'control_guidance_start': 0.0,
+            'control_guidance_end': 1.0,
+        }
+        controlnet_configs.append(config)
+
+    return controlnet_configs
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Build TensorRT engines for StreamDiffusion")
@@ -40,6 +61,13 @@ def parse_args():
         help="Height of the output image (default: 512)"
     )
 
+    parser.add_argument(
+        "--controlnets",
+        type=str,
+        default="",
+        help="Space-separated list of ControlNet model IDs to compile (e.g. 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth')"
+    )
+
     return parser.parse_args()
 
 def main():
@@ -58,6 +86,17 @@ def main():
     print(f"Expected latent dimensions: {latent_width}x{latent_height}")
     print(f"Engines will be saved to: {args.engine_dir}")
 
+    # Create ControlNet configurations if provided
+    controlnet_config = None
+    use_controlnet = False
+    if args.controlnets:
+        controlnet_model_ids = args.controlnets.split()
+        controlnet_config = create_controlnet_configs(controlnet_model_ids, max(args.width, args.height))
+        use_controlnet = True
+        print(f"ControlNets ({len(controlnet_model_ids)}):")
+        for i, cn_id in enumerate(controlnet_model_ids):
+            print(f"  {i}: {cn_id}")
+
     # Initialize wrapper which will trigger TensorRT engine building
     wrapper = StreamDiffusionWrapper(
         mode="img2img",
@@ -68,7 +107,9 @@ def main():
         engine_dir=args.engine_dir,
         width=args.width,
         height=args.height,
-        build_engines_if_missing=True  # Explicitly enable engine building for this script
+        build_engines_if_missing=True,  # Explicitly enable engine building for this script
+        use_controlnet=use_controlnet,
+        controlnet_config=controlnet_config,
     )
 
     print("TensorRT engine building completed successfully!")

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -1,29 +1,37 @@
 import argparse
-from typing import Dict, List, Any
+from typing import List
 
-from streamdiffusion import StreamDiffusionWrapper
+# Make sure 'infer.py' root folder is in PYTHONPATH
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..", "..", "live")))
 
-def create_controlnet_configs(controlnet_model_ids: List[str], width: int, height: int) -> List[Dict[str, Any]]:
-    """Create dummy ControlNet configurations for compilation"""
+from pipelines.streamdiffusion import (
+    load_streamdiffusion_sync,
+    StreamDiffusionParams,
+    ControlNetConfig,
+)
+
+def create_controlnet_configs(controlnet_model_ids: List[str], width: int, height: int) -> List[ControlNetConfig]:
+    """
+    Create dummy ControlNet configurations for compilation using typed models.
+    The exact parameters don't matter for compilation, just need the model to be loaded.
+    """
     controlnet_configs = []
-
     for model_id in controlnet_model_ids:
-        # Create a basic configuration for each ControlNet
-        # The exact parameters don't matter for compilation, just need the model to be loaded
-        config = {
-            'model_id': model_id,
-            'conditioning_scale': 0.5,  # Default scale
-            'preprocessor': "passthrough",  # Simple preprocessor
-            'preprocessor_params': {
+        config = ControlNetConfig(
+            model_id=model_id,
+            conditioning_scale=0.5,
+            preprocessor="passthrough",  # Simplest preprocessor
+            preprocessor_params={
                 "image_width": width,
                 "image_height": height,
             },
-            'enabled': True,
-            'control_guidance_start': 0.0,
-            'control_guidance_end': 1.0,
-        }
+            enabled=True,
+            control_guidance_start=0.0,
+            control_guidance_end=1.0,
+        )
         controlnet_configs.append(config)
-
     return controlnet_configs
 
 def parse_args():
@@ -35,42 +43,36 @@ def parse_args():
         required=True,
         help="Model ID or path to load (e.g. KBlueLeaf/kohaku-v2.1, stabilityai/sd-turbo)"
     )
-
     parser.add_argument(
         "--timesteps",
         type=int,
         default=3,
         help="Number of timesteps in t_index_list (default: 3)"
     )
-
     parser.add_argument(
         "--engine-dir",
         type=str,
         default="engines",
         help="Directory to save TensorRT engines (default: engines)"
     )
-
     parser.add_argument(
         "--width",
         type=int,
         default=512,
         help="Width of the output image (default: 512)"
     )
-
     parser.add_argument(
         "--height",
         type=int,
         default=512,
         help="Height of the output image (default: 512)"
     )
-
     parser.add_argument(
         "--controlnets",
         type=str,
         default="",
         help="Space-separated list of ControlNet model IDs to compile (e.g. 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth')"
     )
-
     return parser.parse_args()
 
 def main():
@@ -90,31 +92,23 @@ def main():
     print(f"Engines will be saved to: {args.engine_dir}")
 
     # Create ControlNet configurations if provided
-    controlnet_config = None
-    use_controlnet = False
+    controlnets = None
     if args.controlnets:
         controlnet_model_ids = args.controlnets.split()
-        controlnet_config = create_controlnet_configs(controlnet_model_ids, args.width, args.height)
-        use_controlnet = True
+        controlnets = create_controlnet_configs(controlnet_model_ids, args.width, args.height)
         print(f"ControlNets ({len(controlnet_model_ids)}):")
         for i, cn_id in enumerate(controlnet_model_ids):
             print(f"  {i}: {cn_id}")
 
-    # Initialize wrapper which will trigger TensorRT engine building
-    wrapper = StreamDiffusionWrapper(
-        mode="img2img",
-        acceleration="tensorrt",
-        frame_buffer_size=1,
-        model_id_or_path=args.model_id,
+    params = StreamDiffusionParams(
+        model_id=args.model_id,
         t_index_list=t_index_list,
-        engine_dir=args.engine_dir,
+        acceleration="tensorrt",
         width=args.width,
         height=args.height,
-        build_engines_if_missing=True,  # Explicitly enable engine building for this script
-        use_controlnet=use_controlnet,
-        controlnet_config=controlnet_config,
+        controlnets=controlnets,
     )
-
+    load_streamdiffusion_sync(params, engine_dir=args.engine_dir, build_engines_if_missing=True)
     print("TensorRT engine building completed successfully!")
 
 if __name__ == "__main__":

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Any
 
 from streamdiffusion import StreamDiffusionWrapper
 
-def create_controlnet_configs(controlnet_model_ids: List[str], image_resolution: int = 512) -> List[Dict[str, Any]]:
+def create_controlnet_configs(controlnet_model_ids: List[str], width: int, height: int) -> List[Dict[str, Any]]:
     """Create dummy ControlNet configurations for compilation"""
     controlnet_configs = []
 
@@ -14,7 +14,10 @@ def create_controlnet_configs(controlnet_model_ids: List[str], image_resolution:
             'model_id': model_id,
             'conditioning_scale': 0.5,  # Default scale
             'preprocessor': "passthrough",  # Simple preprocessor
-            'preprocessor_params': {"image_resolution": image_resolution},
+            'preprocessor_params': {
+                "image_width": width,
+                "image_height": height,
+            },
             'enabled': True,
             'control_guidance_start': 0.0,
             'control_guidance_end': 1.0,
@@ -91,7 +94,7 @@ def main():
     use_controlnet = False
     if args.controlnets:
         controlnet_model_ids = args.controlnets.split()
-        controlnet_config = create_controlnet_configs(controlnet_model_ids, max(args.width, args.height))
+        controlnet_config = create_controlnet_configs(controlnet_model_ids, args.width, args.height)
         use_controlnet = True
         print(f"ControlNets ({len(controlnet_model_ids)}):")
         for i, cn_id in enumerate(controlnet_model_ids):

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -10,6 +10,7 @@ CONDA_PYTHON="/workspace/miniconda3/envs/comfystream/bin/python"
 MODELS="stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1"
 TIMESTEPS="3 4" # This is basically the supported sizes for the t_index_list
 DIMENSIONS="384x704 704x384"
+CONTROLNETS="" # Default empty, will be set from command line
 
 # Function to display help
 function display_help() {
@@ -43,6 +44,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --output-dir)
             OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --controlnets)
+            CONTROLNETS="$2"
             shift 2
             ;;
         --help)
@@ -92,6 +97,11 @@ echo "Models: $MODELS"
 echo "Timesteps: $TIMESTEPS"
 echo "Dimensions: $DIMENSIONS"
 echo "Output directory: $OUTPUT_DIR"
+if [ -n "$CONTROLNETS" ]; then
+    echo "ControlNets: $CONTROLNETS"
+else
+    echo "ControlNets: None"
+fi
 echo
 
 total_builds=0
@@ -130,7 +140,8 @@ for model in $MODELS; do
                 --timesteps "$timestep" \
                 --width "$width" \
                 --height "$height" \
-                --engine-dir "$OUTPUT_DIR"; then
+                --engine-dir "$OUTPUT_DIR" \
+                --controlnets "$CONTROLNETS"; then
                 echo "  ✓ Success"
             else
                 echo "  ✗ Failed"

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -27,6 +27,7 @@ function display_help() {
 }
 
 # Default values
+MODELS_DIR=${HUGGINGFACE_HUB_CACHE:-./models}
 OUTPUT_DIR="./engines"
 BUILD_DEPTH_ANYTHING=false
 
@@ -189,7 +190,7 @@ function build_depth_anything_engine() {
     fi
 
     echo "Locating Depth-Anything ONNX model..."
-    onnx_path=$(find /models -name "depth_anything_v2_vits.onnx" 2>/dev/null | head -1)
+    onnx_path=$(find "$MODELS_DIR" -name "depth_anything_v2_vits.onnx" 2>/dev/null | head -1)
 
     if [ -z "$onnx_path" ] || [ ! -f "$onnx_path" ]; then
         echo "ERROR: Depth-Anything ONNX model not found"

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -130,6 +130,7 @@ function download_streamdiffusion_live_models() {
   # StreamDiffusion
   huggingface-cli download KBlueLeaf/kohaku-v2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
   huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download yuvraj108c/Depth-Anything-2-Onnx --include "depth_anything_v2_vits.onnx" --cache-dir models
 }
 
 function download_comfyui_live_models() {
@@ -205,7 +206,8 @@ function build_streamdiffusion_tensorrt() {
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '3' \
               --dimensions '384x704 512x512 704x384' \
-              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11f1p_sd15_canny lllyasviel/control_v11p_sd15_lineart' \
+              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_lineart' \
+              --build-depth-anything \
               && \
             adduser $(id -u -n) && \
             chown -R $(id -u -n):$(id -g -n) /models" \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -206,7 +206,7 @@ function build_streamdiffusion_tensorrt() {
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '3' \
               --dimensions '384x704 512x512 704x384' \
-              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_lineart' \
+              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_canny lllyasviel/control_v11p_sd15_lineart' \
               --build-depth-anything \
               && \
             adduser $(id -u -n) && \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -201,7 +201,12 @@ function build_streamdiffusion_tensorrt() {
   docker image tag $AI_RUNNER_STREAMDIFFUSION_IMAGE livepeer/ai-runner:live-app-streamdiffusion
 
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_STREAMDIFFUSION_IMAGE \
-    bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' --timesteps '3' --dimensions '384x704 512x512 704x384' && \
+    bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh \
+              --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
+              --timesteps '3' \
+              --dimensions '384x704 512x512 704x384' \
+              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11f1p_sd15_canny lllyasviel/control_v11p_sd15_lineart' \
+              && \
             adduser $(id -u -n) && \
             chown -R $(id -u -n):$(id -g -n) /models" \
     || (echo "failed streamdiffusion tensorrt"; return 1)

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -43,7 +43,8 @@ RUN conda run -n comfystream pip install --no-cache-dir --upgrade --root-user-ac
     tensorrt-cu12-bindings==10.12.0.36 \
     tensorrt-cu12-libs==10.12.0.36 \
     polygraphy==0.49.24 \
-    onnx-graphsurgeon==0.5.8
+    onnx-graphsurgeon==0.5.8 \
+    controlnet-aux==0.0.10
 
 WORKDIR /app
 

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -44,7 +44,8 @@ RUN conda run -n comfystream pip install --no-cache-dir --upgrade --root-user-ac
     tensorrt-cu12-libs==10.12.0.36 \
     polygraphy==0.49.24 \
     onnx-graphsurgeon==0.5.8 \
-    controlnet-aux==0.0.10
+    controlnet-aux==0.0.10 \
+    mediapipe==0.10.21
 
 WORKDIR /app
 


### PR DESCRIPTION
This is to implement support for the controlnet pipeline described by the config yaml in the end
of this description.

Converted the format to the JSON params already received by the pipeline and added dependencies
for executing the provided controlnets. The default params were made to match that config yaml, but
it could be provided dynamically from the stream as well.

We can iterate further adding support to other controlnets, but this already adds the groundwork and
sets the patterns for how to do so.

## Reference pipeline config

```yaml
model_id: "KBlueLeaf/kohaku-v2.1"
t_index_list: [0, 16, 32]
width: 512
height: 512
device: "cuda"
dtype: "float16"

# Generation parameters
prompt: "an anime render of a girl with purple hair, masterpiece"
negative_prompt: "blurry, low quality, flat, 2d"
guidance_scale: 1.1
num_inference_steps: 50

use_denoising_batch: true
delta: 0.7
frame_buffer_size: 1

# Advanced parameters
pipeline_type: "sd1.5"
use_lcm_lora: true
use_tiny_vae: true
acceleration: "tensorrt"
cfg_type: "self"
seed: 789

engine_dir: "./engines"

# ControlNet configuration with TensorRT Depth Anything
controlnets:
  - model_id: "lllyasviel/control_v11f1p_sd15_depth"
    conditioning_scale: 0.28
    preprocessor: "depth_tensorrt"
    preprocessor_params:
      engine_path: "C:\\_dev\\comfy\\ComfyUI\\models\\tensorrt\\depth-anything\\v2_depth_anything_v2_vits-fp16.engine"
      detect_resolution: 518
      image_resolution: 512
    enabled: true

  - model_id: "lllyasviel/control_v11p_sd15_canny"
    conditioning_scale: 0.29
    preprocessor: "canny"
    preprocessor_params:
      low_threshold: 100
      high_threshold: 200
    enabled: true

  - model_id: "lllyasviel/control_v11f1e_sd15_tile"
    conditioning_scale: 0.2
    preprocessor: "passthrough"
    preprocessor_params:
      image_resolution: 512
    enabled: true

  - model_id: "lllyasviel/control_v11p_sd15_lineart"
    conditioning_scale: 0.0
    preprocessor: "standard_lineart"
    preprocessor_params:
      detect_resolution: 512        # int, resolution for detection
      image_resolution: 512         # int, final output resolution
      gaussian_sigma: 6.0          # float, Gaussian blur sigma
      intensity_threshold: 8       # int, intensity calculation threshold
```