### PR TITLE
streamdiffusion: Update to latest lib and controlnets

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -91,6 +91,15 @@ class StreamDiffusionParams(BaseModel):
             control_guidance_end=1.0,
         ),
         ControlNetConfig(
+            model_id="lllyasviel/control_v11p_sd15_openpose",
+            conditioning_scale=0.2,
+            preprocessor="pose_tensorrt",
+            preprocessor_params={},
+            enabled=True,
+            control_guidance_start=0.0,
+            control_guidance_end=1.0,
+        ),
+        ControlNetConfig(
             model_id="lllyasviel/control_v11p_sd15_lineart",
             conditioning_scale=0.0,
             preprocessor="standard_lineart",
@@ -208,15 +217,21 @@ def _prepare_controlnet_configs(params: StreamDiffusionParams) -> Optional[List[
         preprocessor_params = (cn_config.preprocessor_params or {}).copy()
 
         # Inject preprocessor-specific parameters
-        if cn_config.preprocessor == "depth_tensorrt":
+        if cn_config.preprocessor == "canny":
+            # no enforced params
+            pass
+        elif cn_config.preprocessor == "depth_tensorrt":
             preprocessor_params.update({
                 "engine_path": "./engines/depth-anything/depth_anything_v2_vits.engine",
                 "detect_resolution": 518,
                 "image_resolution": 512
             })
-        elif cn_config.preprocessor == "canny":
-            # no enforced params
-            pass
+        elif cn_config.preprocessor == "pose_tensorrt":
+            preprocessor_params.update({
+                "engine_path": "./engines/pose/yolo_nas_pose_l_0.5.engine",
+                "detect_resolution": 640,
+                "image_resolution": 512
+            })
         elif cn_config.preprocessor == "passthrough":
             preprocessor_params.update({
                 "image_width": params.width,

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -214,25 +214,16 @@ def _prepare_controlnet_configs(params: StreamDiffusionParams) -> Optional[List[
         preprocessor_params = (cn_config.preprocessor_params or {}).copy()
 
         # Inject preprocessor-specific parameters
-        if cn_config.preprocessor in ["canny", "hed", "soft_edge"]:
+        if cn_config.preprocessor in ["canny", "hed", "soft_edge", "passthrough"]:
             # no enforced params
             pass
         elif cn_config.preprocessor == "depth_tensorrt":
             preprocessor_params.update({
                 "engine_path": "./engines/depth-anything/depth_anything_v2_vits.engine",
-                "detect_resolution": 518,
-                "image_resolution": 512
             })
         elif cn_config.preprocessor == "pose_tensorrt":
             preprocessor_params.update({
                 "engine_path": "./engines/pose/yolo_nas_pose_l_0.5.engine",
-                "detect_resolution": 640,
-                "image_resolution": 512
-            })
-        elif cn_config.preprocessor == "passthrough":
-            preprocessor_params.update({
-                "image_width": params.width,
-                "image_height": params.height
             })
         else:
             raise ValueError(f"Unrecognized preprocessor: {cn_config.preprocessor}")

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -12,7 +12,7 @@ from pipelines.streamdiffusion import (
     ControlNetConfig,
 )
 
-def create_controlnet_configs(controlnet_model_ids: List[str], width: int, height: int) -> List[ControlNetConfig]:
+def create_controlnet_configs(controlnet_model_ids: List[str]) -> List[ControlNetConfig]:
     """
     Create dummy ControlNet configurations for compilation using typed models.
     The exact parameters don't matter for compilation, just need the model to be loaded.
@@ -23,10 +23,7 @@ def create_controlnet_configs(controlnet_model_ids: List[str], width: int, heigh
             model_id=model_id,
             conditioning_scale=0.5,
             preprocessor="passthrough",  # Simplest preprocessor
-            preprocessor_params={
-                "image_width": width,
-                "image_height": height,
-            },
+            preprocessor_params={},
             enabled=True,
             control_guidance_start=0.0,
             control_guidance_end=1.0,
@@ -95,7 +92,7 @@ def main():
     controlnets = None
     if args.controlnets:
         controlnet_model_ids = args.controlnets.split()
-        controlnets = create_controlnet_configs(controlnet_model_ids, args.width, args.height)
+        controlnets = create_controlnet_configs(controlnet_model_ids)
         print(f"ControlNets ({len(controlnet_model_ids)}):")
         for i, cn_id in enumerate(controlnet_model_ids):
             print(f"  {i}: {cn_id}")

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -3,6 +3,7 @@
 # Internal TensorRT engine build script that runs inside the container
 # This script is designed to be executed within the AI runner container environment
 
+set -e
 [ -v DEBUG ] && set -x
 
 # Configuration
@@ -184,20 +185,19 @@ function build_depth_anything_engine() {
     echo "Building Depth-Anything TensorRT engine..."
 
     engine_path="$OUTPUT_DIR/depth-anything/depth_anything_v2_vits.engine"
-    mkdir -p $(dirname "$engine_path")
 
+    if [ -f "$engine_path" ]; then
+        echo "Engine already exists at: $engine_path"
+        echo "Skipping build."
+        return 0
+    fi
+    mkdir -p $(dirname "$engine_path")
 
     if [ ! -d "ComfyUI-Depth-Anything-Tensorrt" ]; then
         git clone https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt.git \
             && cd ComfyUI-Depth-Anything-Tensorrt \
             && git checkout 1f4c161949b3616516745781fb91444e6443cc25 2>/dev/null \
             && cd ..
-    fi
-
-    if [ -f "$engine_path" ]; then
-        echo "Engine already exists at: $engine_path"
-        echo "Skipping build."
-        return 0
     fi
 
     echo "Locating Depth-Anything ONNX model..."
@@ -230,6 +230,12 @@ function build_pose_engine() {
     echo "Building YoloNas Pose TensorRT engine..."
 
     engine_path="$OUTPUT_DIR/pose/yolo_nas_pose_l_0.5.engine"
+
+    if [ -f "$engine_path" ]; then
+        echo "Engine already exists at: $engine_path"
+        echo "Skipping build."
+        return 0
+    fi
     mkdir -p $(dirname "$engine_path")
 
     if [ ! -d "ComfyUI-YoloNasPose-Tensorrt" ]; then
@@ -238,12 +244,6 @@ function build_pose_engine() {
             && git checkout 873de560bb05bf3331e4121f393b83ecc04c324a 2>/dev/null \
             && $CONDA_PYTHON -m pip install -r requirements.txt \
             && cd ..
-    fi
-
-    if [ -f "$engine_path" ]; then
-        echo "Engine already exists at: $engine_path"
-        echo "Skipping build."
-        return 0
     fi
 
     echo "Locating YoloNas Pose ONNX model..."
@@ -256,8 +256,6 @@ function build_pose_engine() {
     fi
 
     echo "Found ONNX model at: $onnx_path"
-
-
 
     # The export_trt.py script expects a hardcoded path to the model and engine, so create a link
     cd ComfyUI-YoloNasPose-Tensorrt

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -257,16 +257,27 @@ function build_pose_engine() {
 
     echo "Found ONNX model at: $onnx_path"
 
-    echo "Calling export_trt.py to build engine: $engine_path"
-    if $CONDA_PYTHON ./ComfyUI-YoloNasPose-Tensorrt/export_trt.py \
-        --trt-path="$engine_path" \
-        --onnx-path="$onnx_path"; then
-        echo "  ✓ YoloNas Pose TensorRT engine built successfully"
+
+
+    # The export_trt.py script expects a hardcoded path to the model and engine, so create a link
+    cd ComfyUI-YoloNasPose-Tensorrt
+    ln -sf "$onnx_path" "yolo_nas_pose_l.onnx"
+
+    echo "Calling export_trt.py to build engine in temporary directory..."
+    if $CONDA_PYTHON export_trt.py; then
+        if [ -f "yolo_nas_pose_l.engine" ]; then
+            mv "yolo_nas_pose_l.engine" "$engine_path"
+            echo "  ✓ YoloNas Pose TensorRT engine built successfully"
+        else
+            echo "  ✗ Engine file not found in expected location"
+            return 1
+        fi
     else
         echo "  ✗ Failed to build YoloNas Pose TensorRT engine"
         return 1
     fi
 
+    cd ..
     echo
 }
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -207,7 +207,7 @@ function build_streamdiffusion_tensorrt() {
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '3' \
               --dimensions '384x704 512x512 704x384' \
-              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_canny lllyasviel/control_v11p_sd15_lineart' \
+              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_canny lllyasviel/control_v11p_sd15_lineart lllyasviel/control_v11p_sd15_openpose' \
               --build-depth-anything \
               --build-pose \
               && \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -131,6 +131,15 @@ function download_streamdiffusion_live_models() {
   # StreamDiffusion
   huggingface-cli download KBlueLeaf/kohaku-v2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
   huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+
+  # ControlNet models
+  huggingface-cli download thibaud/controlnet-sd21-openpose-diffusers --include "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download thibaud/controlnet-sd21-hed-diffusers --include "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download thibaud/controlnet-sd21-canny-diffusers --include "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download thibaud/controlnet-sd21-depth-diffusers --include "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download thibaud/controlnet-sd21-color-diffusers --include "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+
+  # Preprocessor models
   huggingface-cli download yuvraj108c/Depth-Anything-2-Onnx --include "depth_anything_v2_vits.onnx" --cache-dir models
   huggingface-cli download yuvraj108c/yolo-nas-pose-onnx --include "yolo_nas_pose_l_0.5.onnx" --cache-dir models
 }
@@ -208,7 +217,7 @@ function build_streamdiffusion_tensorrt() {
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '3' \
               --dimensions '384x704 512x512 704x384' \
-              --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_canny lllyasviel/control_v11p_sd15_lineart lllyasviel/control_v11p_sd15_openpose' \
+              --controlnets 'thibaud/controlnet-sd21-openpose-diffusers thibaud/controlnet-sd21-hed-diffusers thibaud/controlnet-sd21-canny-diffusers thibaud/controlnet-sd21-depth-diffusers thibaud/controlnet-sd21-color-diffusers' \
               --build-depth-anything \
               --build-pose \
               && \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -131,6 +131,7 @@ function download_streamdiffusion_live_models() {
   huggingface-cli download KBlueLeaf/kohaku-v2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
   huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
   huggingface-cli download yuvraj108c/Depth-Anything-2-Onnx --include "depth_anything_v2_vits.onnx" --cache-dir models
+  huggingface-cli download yuvraj108c/yolo-nas-pose-onnx --include "yolo_nas_pose_l_0.5.onnx" --cache-dir models
 }
 
 function download_comfyui_live_models() {
@@ -208,6 +209,7 @@ function build_streamdiffusion_tensorrt() {
               --dimensions '384x704 512x512 704x384' \
               --controlnets 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11p_sd15_canny lllyasviel/control_v11p_sd15_lineart' \
               --build-depth-anything \
+              --build-pose \
               && \
             adduser $(id -u -n) && \
             chown -R $(id -u -n):$(id -g -n) /models" \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 [ -v DEBUG ] && set -x
 
 # ComfyUI image configuration

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -29,8 +29,8 @@ RUN conda run -n comfystream pip install --no-cache-dir \
     xformers===0.0.30 \
     --index-url https://download.pytorch.org/whl/cu126
 
-# Install StreamDiffusion @ v0.0.1-cnet.2 (latest with controlnet support) into the comfystream environment
-RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@v0.0.1-cnet.2#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ v0.0.1-cnet.3 (latest with controlnet support) into the comfystream environment
+RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@v0.0.1-cnet.3#egg=streamdiffusion[tensorrt]
 
 # Pin versions of ONNX runtime which are too loose on streamdiffusion setup.py
 RUN conda run -n comfystream pip install --no-cache-dir \


### PR DESCRIPTION
This adds the actual controlnets we want for the first iteration of the controlnet pipeline,
using sd-turbo and the 5 controlnets: depth, canny, pose, color and hed 