### PR TITLE
streamdiffusion: Fallback to previous params on update failure

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -179,8 +179,15 @@ class StreamDiffusion(Pipeline):
                 logging.error(f"Error updating parameters dynamically: {e}")
 
             logging.info(f"Resetting pipeline for params change")
+
             self.pipe = None
-            self.pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
+            try:
+                self.pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
+            except Exception as e:
+                logging.error(f"Error resetting pipeline, reloading with previous params: {e}")
+                new_params = self.params or StreamDiffusionParams()
+                self.pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
+
             self.params = new_params
             self.first_frame = True
 

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -183,8 +183,8 @@ class StreamDiffusion(Pipeline):
             self.pipe = None
             try:
                 self.pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
-            except Exception as e:
-                logging.error(f"Error resetting pipeline, reloading with previous params: {e}")
+            except Exception:
+                logging.error(f"Error resetting pipeline, reloading with previous params", exc_info=True)
                 new_params = self.params or StreamDiffusionParams()
                 self.pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
 


### PR DESCRIPTION
We were only handling exceptions on initial pipeline load, on the process loop itself,
but on update it ended up without a pipeline object set up.

The annoying part is that we do have to freeze the inference anyway cause we dont have
VRAM to load 2 pipelines at once. So if you send invalid params it's gonna take a while.