### PR TITLE
docker: Pin torch versions based on built image

### DIFF
--- a/runner/docker/Dockerfile.live-app__PIPELINE__
+++ b/runner/docker/Dockerfile.live-app__PIPELINE__
@@ -17,10 +17,10 @@ RUN --mount=type=bind,source=requirements.live-ai.txt,target=/tmp/requirements.t
     conda run -n comfystream pip install --root-user-action ignore --requirement /tmp/requirements.txt
 
 RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
-    torch \
-    torchvision \
-    torchaudio \
-    pytorch_triton \
+    torch==2.7.1+cu128 \
+    torchvision==0.22.1+cu128 \
+    torchaudio==2.7.1+cu128 \
+    pytorch_triton==3.3.0 \
     --index-url https://download.pytorch.org/whl/cu128 && \
     # due to installation from requirements.txt the numpy version should be 1.26.4 for compatibility
     conda run -n comfystream pip install --no-cache-dir \

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -22,9 +22,9 @@ RUN apt update && apt install -yqq --no-install-recommends wget curl ca-certific
 
 # Install StreamDiffusion dependencies into the comfystream environment
 RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
-    torch \
-    torchvision \
-    torchaudio \
+    torch==2.7.1+cu128 \
+    torchvision==0.22.1+cu128 \
+    torchaudio==2.7.1+cu128 \
     --index-url https://download.pytorch.org/whl/cu128 && \
     conda run -n comfystream pip install --no-cache-dir \
     xformers==0.0.30 --no-deps


### PR DESCRIPTION
Meaning I just ran pip freeze on the output image and pinned to the exxact versions that were installed in hte end.

Follow-up from #673 