### PR TITLE
streamdiffusion: Dynamic resolution TensorRT engines

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -248,8 +248,6 @@ class StreamDiffusion(Pipeline):
             # at this point, we know it's an updatable parameter that changed
             if key == 'prompt':
                 update_kwargs['prompt_list'] = [(new_value, 1.0)] if isinstance(new_value, str) else new_value
-            elif key == 'prompt_interpolation_method':
-                update_kwargs['interpolation_method'] = new_value
             elif key == 'seed':
                 update_kwargs['seed_list'] = [(new_value, 1.0)] if isinstance(new_value, int) else new_value
             else:
@@ -374,7 +372,7 @@ def load_streamdiffusion_sync(params: StreamDiffusionParams, engine_dir = "engin
 
     pipe.prepare(
         prompt=params.prompt,
-        interpolation_method=params.prompt_interpolation_method,
+        prompt_interpolation_method=params.prompt_interpolation_method,
         negative_prompt=params.negative_prompt,
         num_inference_steps=params.num_inference_steps,
         guidance_scale=params.guidance_scale,

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -216,8 +216,6 @@ class StreamDiffusion(Pipeline):
 
         update_kwargs = {}
         controlnet_scale_changes: List[Tuple[int, float]] = []
-        normalize_prompt_weights_changed = False
-        normalize_seed_weights_changed = False
         curr_params = self.params.model_dump() if self.params else {}
         for key, new_value in new_params.model_dump().items():
             curr_value = curr_params.get(key, None)
@@ -236,14 +234,6 @@ class StreamDiffusion(Pipeline):
                     return False
                 # do not add controlnets to update_kwargs
                 continue
-            elif key == 'normalize_prompt_weights':
-                normalize_prompt_weights_changed = True
-                # do not add normalize_weights to update_kwargs
-                continue
-            elif key == 'normalize_seed_weights':
-                normalize_seed_weights_changed = True
-                # do not add normalize_weights to update_kwargs
-                continue
 
             # at this point, we know it's an updatable parameter that changed
             if key == 'prompt':
@@ -257,10 +247,6 @@ class StreamDiffusion(Pipeline):
 
         if update_kwargs:
             self.pipe.update_stream_params(**update_kwargs)
-        if normalize_prompt_weights_changed:
-            self.pipe.set_normalize_prompt_weights(new_params.normalize_prompt_weights)
-        if normalize_seed_weights_changed:
-            self.pipe.set_normalize_seed_weights(new_params.normalize_seed_weights)
         for i, scale in controlnet_scale_changes:
             self.pipe.update_controlnet_scale(i, scale)
 

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -199,7 +199,6 @@ class StreamDiffusion(Pipeline):
             'num_inference_steps', 'guidance_scale', 'delta', 't_index_list',
             'seed', 'prompt', 'prompt_interpolation_method', 'negative_prompt',
             'seed_interpolation_method', 'controlnets', 'normalize_weights',
-            'width', 'height',
         }
 
         update_kwargs = {}

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -40,8 +40,8 @@ class StreamDiffusionParams(BaseModel):
     t_index_list: List[int] = [12, 20, 32]
 
     # Image dimensions
-    width: int = Field(default=DEFAULT_WIDTH, ge=384, le=1024)
-    height: int = Field(default=DEFAULT_HEIGHT, ge=384, le=1024)
+    width: int = Field(default=DEFAULT_WIDTH, ge=384, le=1024, multiple_of=64)
+    height: int = Field(default=DEFAULT_HEIGHT, ge=384, le=1024, multiple_of=64)
 
     # LoRA settings
     lora_dict: Optional[Dict[str, float]] = None

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Dict, List, Literal, Optional, Any, Tuple, cast
 
 import torch
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from streamdiffusion import StreamDiffusionWrapper
 
 from .interface import Pipeline
@@ -40,8 +40,8 @@ class StreamDiffusionParams(BaseModel):
     t_index_list: List[int] = [12, 20, 32]
 
     # Image dimensions
-    width: int = DEFAULT_WIDTH
-    height: int = DEFAULT_HEIGHT
+    width: int = Field(default=DEFAULT_WIDTH, ge=384, le=1024)
+    height: int = Field(default=DEFAULT_HEIGHT, ge=384, le=1024)
 
     # LoRA settings
     lora_dict: Optional[Dict[str, float]] = None

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -198,7 +198,8 @@ class StreamDiffusion(Pipeline):
         updatable_params = {
             'num_inference_steps', 'guidance_scale', 'delta', 't_index_list',
             'seed', 'prompt', 'prompt_interpolation_method', 'negative_prompt',
-            'seed_interpolation_method', 'controlnets', 'normalize_weights'
+            'seed_interpolation_method', 'controlnets', 'normalize_weights',
+            'width', 'height',
         }
 
         update_kwargs = {}

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -210,8 +210,9 @@ class StreamDiffusion(Pipeline):
 
         updatable_params = {
             'num_inference_steps', 'guidance_scale', 'delta', 't_index_list',
-            'seed', 'prompt', 'prompt_interpolation_method', 'negative_prompt',
-            'seed_interpolation_method', 'controlnets', 'normalize_weights',
+            'prompt', 'prompt_interpolation_method', 'normalize_prompt_weights', 'negative_prompt',
+            'seed', 'seed_interpolation_method', 'normalize_seed_weights',
+            'controlnets', # handled separately below
         }
 
         update_kwargs = {}
@@ -221,7 +222,7 @@ class StreamDiffusion(Pipeline):
             curr_value = curr_params.get(key, None)
             if new_value == curr_value:
                 continue
-            elif key not in updatable_params and new_value != curr_value:
+            elif key not in updatable_params:
                 logging.info(f"Non-updatable parameter changed: {key}")
                 return False
             elif key == 't_index_list' and len(new_value) != len(curr_value or []):

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -13,7 +13,13 @@ from trickle import DEFAULT_WIDTH, DEFAULT_HEIGHT
 
 class ControlNetConfig(BaseModel):
     """ControlNet configuration model"""
-    model_id: str
+    model_id: Literal[
+        "thibaud/controlnet-sd21-openpose-diffusers",
+        "thibaud/controlnet-sd21-hed-diffusers",
+        "thibaud/controlnet-sd21-canny-diffusers",
+        "thibaud/controlnet-sd21-depth-diffusers",
+        "thibaud/controlnet-sd21-color-diffusers"
+    ]
     conditioning_scale: float = 1.0
     preprocessor: Optional[str] = None
     preprocessor_params: Optional[Dict[str, Any]] = None
@@ -27,7 +33,10 @@ class StreamDiffusionParams(BaseModel):
         extra = "forbid"
 
     # Model configuration
-    model_id: str = "stabilityai/sd-turbo"
+    model_id: Literal[
+        "stabilityai/sd-turbo",
+        "KBlueLeaf/kohaku-v2.1",
+    ] = "stabilityai/sd-turbo"
 
     # Generation parameters
     prompt: str | List[Tuple[str, float]] = "an anime render of a girl with purple hair, masterpiece"

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -10,7 +10,7 @@ set -e
 CONDA_PYTHON="/workspace/miniconda3/envs/comfystream/bin/python"
 MODELS="stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1"
 TIMESTEPS="3 4" # This is basically the supported sizes for the t_index_list
-DIMENSIONS="384x704 704x384"
+DIMENSIONS="512x512" # Engines are now compiled for the 384-1024 range, but keep this in case it's useful in the future
 CONTROLNETS="" # Default empty, will be set from command line
 
 # Function to display help

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -216,7 +216,6 @@ function build_streamdiffusion_tensorrt() {
     bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh \
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '3' \
-              --dimensions '384x704 512x512 704x384' \
               --controlnets 'thibaud/controlnet-sd21-openpose-diffusers thibaud/controlnet-sd21-hed-diffusers thibaud/controlnet-sd21-canny-diffusers thibaud/controlnet-sd21-depth-diffusers thibaud/controlnet-sd21-color-diffusers' \
               --build-depth-anything \
               --build-pose \

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -29,8 +29,8 @@ RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
     conda run -n comfystream pip install --no-cache-dir \
     xformers==0.0.30 --no-deps
 
-# Install StreamDiffusion @ 23f5d7d into the comfystream environment
-RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@23f5d7d6a4bf89fd35104346442cb15ac6e48c5c#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ 63bc37a into the comfystream environment
+RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@63bc37a8bf1a8b4dbc9b0a61de6bd6b021cb56a5#egg=streamdiffusion[tensorrt]
 
 # Pin versions of ONNX runtime which are too loose on streamdiffusion setup.py
 RUN conda run -n comfystream pip install --no-cache-dir \

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -29,8 +29,8 @@ RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
     conda run -n comfystream pip install --no-cache-dir \
     xformers==0.0.30 --no-deps
 
-# Install StreamDiffusion @ v0.0.1-cnet.3 (latest with controlnet support) into the comfystream environment
-RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@v0.0.1-cnet.3#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ 23f5d7d into the comfystream environment
+RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@23f5d7d6a4bf89fd35104346442cb15ac6e48c5c#egg=streamdiffusion[tensorrt]
 
 # Pin versions of ONNX runtime which are too loose on streamdiffusion setup.py
 RUN conda run -n comfystream pip install --no-cache-dir \

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -29,8 +29,8 @@ RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
     conda run -n comfystream pip install --no-cache-dir \
     xformers==0.0.30 --no-deps
 
-# Install StreamDiffusion @ 63bc37a into the comfystream environment
-RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@63bc37a8bf1a8b4dbc9b0a61de6bd6b021cb56a5#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ 7d62da2 into the comfystream environment
+RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@7d62da24b9be7aec262346f3a54aa923caa2182e#egg=streamdiffusion[tensorrt]
 
 # Pin versions of ONNX runtime which are too loose on streamdiffusion setup.py
 RUN conda run -n comfystream pip install --no-cache-dir \

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -29,8 +29,8 @@ RUN conda run -n comfystream pip install --no-cache-dir --force-reinstall \
     conda run -n comfystream pip install --no-cache-dir \
     xformers==0.0.30 --no-deps
 
-# Install StreamDiffusion @ 7d62da2 into the comfystream environment
-RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@7d62da24b9be7aec262346f3a54aa923caa2182e#egg=streamdiffusion[tensorrt]
+# Install StreamDiffusion @ v0.0.1-cnet.4 into the comfystream environment
+RUN conda run -n comfystream pip install git+https://github.com/livepeer/StreamDiffusion.git@v0.0.1-cnet.4#egg=streamdiffusion[tensorrt]
 
 # Pin versions of ONNX runtime which are too loose on streamdiffusion setup.py
 RUN conda run -n comfystream pip install --no-cache-dir \


### PR DESCRIPTION
This upgrades the streamdiffusion lib to add support to the dynamic tensorrt engines.

This will allow us to switch resolution of the pipeline (i.e. between different streams) without
requiring a full reload, being much quicker.