### PR TITLE
dl_checkpoints: Improvements to tensorrt compilation

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -81,9 +81,7 @@ class StreamDiffusionParams(BaseModel):
             model_id="thibaud/controlnet-sd21-openpose-diffusers",
             conditioning_scale=0.711,
             preprocessor="pose_tensorrt",
-            preprocessor_params={
-                "confidence_threshold": 0.5,
-            },
+            preprocessor_params={},
             enabled=True,
             control_guidance_start=0.0,
             control_guidance_end=1.0,

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -76,7 +76,7 @@ def main():
     args = parse_args()
 
     # Create t_index_list based on number of timesteps. Only the size matters...
-    t_index_list = list(range(0, 50, 50 // args.timesteps))[:args.timesteps]
+    t_index_list = list(range(1, 50, 50 // args.timesteps))[:args.timesteps]
 
     print(f"Building TensorRT engines for model: {args.model_id}")
     print(f"Using {args.timesteps} timesteps: {t_index_list}")

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -141,7 +141,7 @@ function download_streamdiffusion_live_models() {
 
   # Preprocessor models
   huggingface-cli download yuvraj108c/Depth-Anything-2-Onnx --include "depth_anything_v2_vits.onnx" --cache-dir models
-  huggingface-cli download yuvraj108c/yolo-nas-pose-onnx --include "yolo_nas_pose_l_*.onnx" --cache-dir models
+  huggingface-cli download yuvraj108c/yolo-nas-pose-onnx --include "yolo_nas_pose_l_0.5.onnx" --cache-dir models
 }
 
 function download_comfyui_live_models() {

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -214,7 +214,7 @@ function build_streamdiffusion_tensorrt() {
   docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_STREAMDIFFUSION_IMAGE \
     bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh \
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
-              --timesteps '3' \
+              --timesteps '1 2 3 4' \
               --controlnets 'thibaud/controlnet-sd21-openpose-diffusers thibaud/controlnet-sd21-hed-diffusers thibaud/controlnet-sd21-canny-diffusers thibaud/controlnet-sd21-depth-diffusers thibaud/controlnet-sd21-color-diffusers' \
               --build-depth-anything \
               --build-pose \


### PR DESCRIPTION
- Support `t_index_list` from 1 up to 4 timesteps
- Only compile nas pose for `0.5` confidence threshold – it's not that useful and was taking 1h to compile, so simplify