### PR TITLE
process_guardian: Revert to default params after stream stops

### DIFF
--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -290,6 +290,10 @@ class ProcessGuardian:
                 if state == self.status.state:
                     continue
 
+                if state == PipelineState.OFFLINE:
+                    # Revert to initial params when the stream stops
+                    self.process.update_params(self.initial_params)
+
                 if state != PipelineState.ERROR:
                     # avoid thrashing the state to ERROR if we're going to restart the process below
                     self.status.update_state(state)


### PR DESCRIPTION
We want to be always quick in loading the default params for a new stream, so make sure we revert the stream back to the default when it is done.