### PR TITLE
runner: add data_url to route/pipeline and codegen

### DIFF
--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -30,7 +30,7 @@ class LiveVideoToVideoPipeline(Pipeline):
         self.start_process()
 
     def __call__(  # type: ignore
-        self, *, subscribe_url: str, publish_url: str, control_url: str, events_url: str, params: dict, request_id: str, manifest_id: str, stream_id: str, **kwargs
+        self, *, subscribe_url: str, publish_url: str, control_url: str, events_url: str, data_url: str, params: dict, request_id: str, manifest_id: str, stream_id: str, **kwargs
     ):
         if not self.process:
             raise RuntimeError("Pipeline process not running")
@@ -51,6 +51,7 @@ class LiveVideoToVideoPipeline(Pipeline):
                             "publish_url": publish_url,
                             "control_url": control_url,
                             "events_url": events_url,
+                            "data_url": data_url,
                             "params": params,
                             "request_id": request_id or "",
                             "manifest_id": manifest_id or "",

--- a/runner/app/routes/live_video_to_video.py
+++ b/runner/app/routes/live_video_to_video.py
@@ -58,6 +58,13 @@ class LiveVideoToVideoParams(BaseModel):
             description="URL for publishing events via Trickle protocol for pipeline status and logs.",
         ),
     ]
+    data_url: Annotated[
+        str,
+        Field(
+            default="",
+            description="URL for publishing data via Trickle protocol for pipeline status and logs.",
+        ),
+    ]
     model_id: Annotated[
         str,
         Field(

--- a/runner/gateway.openapi.yaml
+++ b/runner/gateway.openapi.yaml
@@ -1000,6 +1000,12 @@ components:
           description: URL for publishing events via Trickle protocol for pipeline
             status and logs.
           default: ''
+        data_url:
+          type: string
+          title: Data Url
+          description: URL for publishing data via Trickle protocol for pipeline status
+            and logs.
+          default: ''
         model_id:
           type: string
           title: Model Id

--- a/runner/openapi.yaml
+++ b/runner/openapi.yaml
@@ -1158,6 +1158,12 @@ components:
           description: URL for publishing events via Trickle protocol for pipeline
             status and logs.
           default: ''
+        data_url:
+          type: string
+          title: Data Url
+          description: URL for publishing data via Trickle protocol for pipeline status
+            and logs.
+          default: ''
         model_id:
           type: string
           title: Model Id


### PR DESCRIPTION
Bare bones required changes to enable data_url in go-livepeer PR