### PR TITLE
live: Minimize media queue sizes.

### DIFF
--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -28,8 +28,8 @@ class PipelineProcess:
         self.pipeline_name = pipeline_name
         self.ctx = mp.get_context("spawn")
 
-        self.input_queue = self.ctx.Queue(maxsize=2)
-        self.output_queue = self.ctx.Queue()
+        self.input_queue = self.ctx.Queue(maxsize=1)
+        self.output_queue = self.ctx.Queue(maxsize=1)
         self.param_update_queue = self.ctx.Queue()
         self.error_queue = self.ctx.Queue()
         self.log_queue = self.ctx.Queue(maxsize=100)  # Keep last 100 log lines


### PR DESCRIPTION
At 24fps, each frame is ~41ms, so with just a couple in the queue plus the frames that are in-flight on either end of the pipeline, we're already looking at 100+ ms of latency.

Note that we would preferably have separate queues for audio and video but that's a larger change.