### PR TITLE
streamdiffusion: Set HF to offline mode in runtime

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -211,7 +211,9 @@ function build_streamdiffusion_tensorrt() {
   # ai-worker has tags hardcoded in `var livePipelineToImage` so we need to use the same tag in here:
   docker image tag $AI_RUNNER_STREAMDIFFUSION_IMAGE livepeer/ai-runner:live-app-streamdiffusion
 
-  docker run --rm -v ./models:/models --gpus all -l TensorRT-engines $AI_RUNNER_STREAMDIFFUSION_IMAGE \
+  docker run --rm -v ./models:/models --gpus all \
+    -l TensorRT-engines -e HF_HUB_OFFLINE=0 \
+    -n streamdiffusion-tensorrt-build $AI_RUNNER_STREAMDIFFUSION_IMAGE \
     bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh \
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '1 2 3 4' \

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -213,7 +213,7 @@ function build_streamdiffusion_tensorrt() {
 
   docker run --rm -v ./models:/models --gpus all \
     -l TensorRT-engines -e HF_HUB_OFFLINE=0 \
-    -n streamdiffusion-tensorrt-build $AI_RUNNER_STREAMDIFFUSION_IMAGE \
+    --name streamdiffusion-tensorrt-build $AI_RUNNER_STREAMDIFFUSION_IMAGE \
     bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh \
               --models 'stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1' \
               --timesteps '1 2 3 4' \

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -49,5 +49,9 @@ RUN conda run -n comfystream pip install --no-cache-dir --upgrade --root-user-ac
 
 WORKDIR /app
 
+# Disable HF hub connectivity to avoid internet access during runtime.
+# This is manually disabled on the script to download models (dl_checkpoints.sh)
+ENV HF_HUB_OFFLINE=1
+
 # Create symlink for where StreamDiffusion builds TensorRT engines at runtime
 RUN ln -s /models/StreamDiffusion--engines ./engines


### PR DESCRIPTION
- Offline mode by default on the image
- On the dl_checkpoints script we disable it just in case any file is missing during compilation (most are downloaded by the script itself, but let's not be obnoxious)