### PR TITLE
process: Ensure stream is stopped with no inputs

### DIFF
--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -172,11 +172,11 @@ class ProcessGuardian:
                 logging.info(
                     f"Shutting down streamer. Flagging DEGRADED_INPUT state during shutdown: time_since_last_input={time_since_last_input:.1f}s"
                 )
-            return (
-                PipelineState.DEGRADED_INPUT
-                if time_since_last_input < 90
-                else PipelineState.ERROR  # Not shutting down after 30s, declare ERROR
-            )
+            if time_since_last_input < 90:
+                return PipelineState.DEGRADED_INPUT
+            # Stream hasn't shut down 30s after the trigger above (90s total idle time).
+            # Declare ERROR so the container gets restarted by the worker.
+            return PipelineState.ERROR
 
         # Special case: pipeline load
         inference = self.status.inference_status

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -162,11 +162,9 @@ class ProcessGuardian:
         time_since_last_input = current_time - (input.last_input_time or start_time)
 
         if not self.streamer.is_stream_running():
-            return (
-                PipelineState.OFFLINE
-                if time_since_last_input > 3  # 3s grace period after shutdown
-                else PipelineState.DEGRADED_INPUT
-            )
+            # give it 3s `DEGRADED_INPUT` grace period after shutdown
+            is_offline = time_since_last_input > 3 or not input.last_input_time
+            return PipelineState.OFFLINE if is_offline else PipelineState.DEGRADED_INPUT
 
         # Special case: stream shutdown after inactivity
         if time_since_last_input > 60:


### PR DESCRIPTION
It might happen that we never get any input from the stream, we might be forever stuck in the
`DEGRADED_INPUT` state because of [this check](https://github.com/livepeer/ai-worker/blob/c3396d13f00d7d7bb4f831d3503ee0da44fb2005/runner/app/live/streamer/process_guardian.py#L199-L200) that comes before any timeout.

To fix it, I made sure we check for the input timeout before checking for the pipeline loading
conditions. The only side-effect I had to include was making the `time_since_last_input` start
as `0` when the pipeline starts, instead of "+INF" (`current_time`). I've corrected for this
on the only place that I think it'd matter, in the stream shutdown branch.

Implements ENG-3004