### PR TITLE
feat: build_safety_checker

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion_params.py
+++ b/runner/app/live/pipelines/streamdiffusion_params.py
@@ -206,7 +206,7 @@ class StreamDiffusionParams(BaseModel):
     """Acceleration method for inference. TensorRT provides the best performance but requires engine compilation."""
 
     # Processing settings
-    use_safety_checker: bool = True
+    use_safety_checker: bool = False
     """Whether to use the safety checker to prevent generating NSFW images."""
 
     use_denoising_batch: bool = True

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -79,6 +79,12 @@ def parse_args():
         default="",
         help="Space-separated list of ControlNet model IDs to compile (e.g. 'lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11f1p_sd15_depth')"
     )
+    parser.add_argument(
+        "--build-safety-checker",
+        type=bool,
+        default=False,
+        help="Build Safety Checker TensorRT engine"
+    )
     return parser.parse_args()
 
 def main():
@@ -106,6 +112,10 @@ def main():
         for i, cn_id in enumerate(controlnet_model_ids):
             print(f"  {i}: {cn_id}")
 
+    use_safety_checker = False
+    if args.build_safety_checker:
+        use_safety_checker = True
+
     params = StreamDiffusionParams(
         model_id=args.model_id,
         t_index_list=t_index_list,
@@ -113,6 +123,7 @@ def main():
         width=args.width,
         height=args.height,
         controlnets=controlnets,
+        use_safety_checker=use_safety_checker,
     )
     load_streamdiffusion_sync(params, min_batch_size=args.min_timesteps, max_batch_size=args.max_timesteps, engine_dir=args.engine_dir, build_engines_if_missing=True)
     print("TensorRT engine building completed successfully!")

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -29,6 +29,7 @@ function display_help() {
     echo "  --controlnets CONTROLNETS Space-separated list of controlnet models"
     echo "  --build-depth-anything  Build Depth-Anything TensorRT engine (requires ONNX model to be downloaded)"
     echo "  --build-pose            Build YoloNas Pose TensorRT engine (requires ONNX model to be downloaded)"
+    echo "  --build-safety-checker  Build Safety Checker TensorRT engine"
     echo "  --help                  Display this help message"
 }
 
@@ -37,6 +38,7 @@ MODELS_DIR=${HUGGINGFACE_HUB_CACHE:-./models}
 OUTPUT_DIR="./engines"
 BUILD_DEPTH_ANYTHING=false
 BUILD_POSE=false
+BUILD_SAFETY_CHECKER=false
 
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -75,6 +77,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --build-pose)
             BUILD_POSE=true
+            shift
+            ;;
+        --build-safety-checker)
+            BUILD_SAFETY_CHECKER=true
             shift
             ;;
         --help)
@@ -141,6 +147,11 @@ if [ "$BUILD_POSE" = true ]; then
 else
     echo "YoloNas Pose: Disabled"
 fi
+if [ "$BUILD_SAFETY_CHECKER" = true ]; then
+    echo "Safety Checker: Enabled"
+else
+    echo "Safety Checker: Disabled"
+fi
 echo
 
 total_builds=0
@@ -181,7 +192,8 @@ for model in $MODELS; do
             --width "$width" \
             --height "$height" \
             --engine-dir "$OUTPUT_DIR" \
-            --controlnets "$CONTROLNETS"; then
+            --controlnets "$CONTROLNETS" \
+            --build-safety-checker "$BUILD_SAFETY_CHECKER"; then
             echo "  ✓ Success"
         else
             echo "  ✗ Failed"

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -234,6 +234,7 @@ function build_streamdiffusion_tensorrt() {
               --controlnets 'thibaud/controlnet-sd21-openpose-diffusers thibaud/controlnet-sd21-hed-diffusers thibaud/controlnet-sd21-canny-diffusers thibaud/controlnet-sd21-depth-diffusers thibaud/controlnet-sd21-color-diffusers' \
               --build-depth-anything \
               --build-pose \
+              --build-safety-checker \
               && \
             chown -R $(id -u):$(id -g) /models" ||
     (
@@ -250,8 +251,6 @@ function build_streamdiffusion_tensorrt() {
               --min-timesteps '1' \
               --max-timesteps '4' \
               --controlnets 'lllyasviel/control_v11f1p_sd15_depth lllyasviel/control_v11f1e_sd15_tile lllyasviel/control_v11p_sd15_canny' \
-              --build-depth-anything \
-              --build-pose \
               && \
             chown -R $(id -u):$(id -g) /models" ||
     (


### PR DESCRIPTION
- use_safety_checker should usually be switched off because its only needed in human input settings
- given that default now is false add a way to switch it on when building engines because it basically gets build twice if not, once for sd2.1 and then sd1.5
- same with build depth tensorrt and yolo nas tensorrt, it was getting built twice