### PR TITLE
streamdiffusion/sd15: Cleanup models and make OpenJourney default

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion_params.py
+++ b/runner/app/live/pipelines/streamdiffusion_params.py
@@ -30,16 +30,10 @@ CONTROLNETS_BY_TYPE: Dict[ModelType, List[str]] = {
 
 MODEL_ID_TO_TYPE: Dict[str, ModelType] = {
     "stabilityai/sd-turbo": "sd21",
-    "SG161222/Realistic_Vision_V6.0_B1_noVAE": "sd15",
-    "varb15/PerfectPhotonV2.1": "sd15",
     "stabilityai/sdxl-turbo": "sdxl",
-    "Lykon/dreamshaper-8": "sd15",
     "prompthero/openjourney-v4": "sd15",
-    "dreamlike-art/dreamlike-diffusion-1.0": "sd15",
-    "dreamlike-art/dreamlike-photoreal-2.0": "sd15",
-    "danbrown/Lyriel-v1-5": "sd15",
-    "stablediffusionapi/deliberate-v2": "sd15",
-    "Lykon/dreamshaper-8-lcm": "sd15",
+    "varb15/PerfectPhotonV2.1": "sd15",
+    "Lykon/dreamshaper-8": "sd15",
 }
 
 def get_model_type(model_id: str) -> ModelType:
@@ -207,16 +201,10 @@ class StreamDiffusionParams(BaseModel):
     # Model configuration
     model_id: Literal[
         "stabilityai/sd-turbo",
-        "SG161222/Realistic_Vision_V6.0_B1_noVAE",
-        "varb15/PerfectPhotonV2.1",
         "stabilityai/sdxl-turbo",
-        "Lykon/dreamshaper-8",
         "prompthero/openjourney-v4",
-        "dreamlike-art/dreamlike-diffusion-1.0",
-        "dreamlike-art/dreamlike-photoreal-2.0",
-        "danbrown/Lyriel-v1-5",
-        "stablediffusionapi/deliberate-v2",
-        "Lykon/dreamshaper-8-lcm",
+        "varb15/PerfectPhotonV2.1",
+        "Lykon/dreamshaper-8",
     ] = "stabilityai/sd-turbo"
     """Base U-Net model to use for generation."""
 

--- a/runner/app/live/pipelines/streamdiffusion_sd15_default_params.json
+++ b/runner/app/live/pipelines/streamdiffusion_sd15_default_params.json
@@ -1,5 +1,5 @@
 {
-  "model_id": "SG161222/Realistic_Vision_V6.0_B1_noVAE",
+  "model_id": "prompthero/openjourney-v4",
   "prompt": "cyberpunk desert structures, masterpiece",
   "prompt_interpolation_method": "slerp",
   "normalize_prompt_weights": true,

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -131,16 +131,9 @@ function download_streamdiffusion_live_models() {
   # U-net models
   huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
   huggingface-cli download stabilityai/sdxl-turbo --include "*.json" "*.txt" "*/model.safetensors" "*/diffusion_pytorch_model.safetensors" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download varb15/PerfectPhotonV2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  # Additional SD1.5 models under evaluation
-  huggingface-cli download SG161222/Realistic_Vision_V6.0_B1_noVAE --include "*/model.safetensors" "*/diffusion_pytorch_model.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download Lykon/dreamshaper-8 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
   huggingface-cli download prompthero/openjourney-v4 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download dreamlike-art/dreamlike-diffusion-1.0 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download dreamlike-art/dreamlike-photoreal-2.0 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download danbrown/Lyriel-v1-5 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download stablediffusionapi/deliberate-v2 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
-  huggingface-cli download Lykon/dreamshaper-8-lcm --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download varb15/PerfectPhotonV2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
+  huggingface-cli download Lykon/dreamshaper-8 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 
   # SD2.1 (turbo) ControlNet models
   huggingface-cli download thibaud/controlnet-sd21-openpose-diffusers --include "*.bin" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
@@ -259,7 +252,7 @@ function build_streamdiffusion_tensorrt() {
     -l TensorRT-engines -e HF_HUB_OFFLINE=0 \
     --name streamdiffusion-tensorrt-build $AI_RUNNER_STREAMDIFFUSION_IMAGE \
     bash -c "./app/tools/streamdiffusion/build_tensorrt_internal.sh \
-              --models 'SG161222/Realistic_Vision_V6.0_B1_noVAE varb15/PerfectPhotonV2.1 Lykon/dreamshaper-8 prompthero/openjourney-v4 dreamlike-art/dreamlike-diffusion-1.0 dreamlike-art/dreamlike-photoreal-2.0 danbrown/Lyriel-v1-5 stablediffusionapi/deliberate-v2 Lykon/dreamshaper-8-lcm' \
+              --models 'prompthero/openjourney-v4 varb15/PerfectPhotonV2.1 Lykon/dreamshaper-8' \
               --opt-timesteps '3' \
               --min-timesteps '1' \
               --max-timesteps '4' \


### PR DESCRIPTION
After a bunch of testing, decided on going with OpenJourney as the default SD15 model.
It is both less NSFW-leaning as well as more consistent than PerfectPhoton on the tests I made.
Tried a bunch of other models as well (the ones being removed) and it seemed to perform generally best.