### PR TITLE
streamdiffusion: Report internal errors updating parameters

### DIFF
--- a/runner/app/live/pipelines/interface.py
+++ b/runner/app/live/pipelines/interface.py
@@ -19,6 +19,19 @@ class Pipeline(ABC):
         pass
 
     @abstractmethod
+    async def initialize(self, **params):
+        """Initialize the pipeline with parameters and warm up the processing.
+
+        This method sets up the initial pipeline state and performs warmup operations.
+        Must maintain valid state on success or restore previous state on failure.
+        Starts the pipeline loops in comfystream.
+
+        Args:
+            **params: Implementation-specific parameters
+        """
+        pass
+
+    @abstractmethod
     async def put_video_frame(self, frame: VideoFrame, request_id: str):
         """Put a frame into the pipeline.
 
@@ -33,19 +46,6 @@ class Pipeline(ABC):
 
         Returns:
             Processed VideoFrame
-        """
-        pass
-
-    @abstractmethod
-    async def initialize(self, **params):
-        """Initialize the pipeline with parameters and warm up the processing.
-
-        This method sets up the initial pipeline state and performs warmup operations.
-        Must maintain valid state on success or restore previous state on failure.
-        Starts the pipeline loops in comfystream.
-
-        Args:
-            **params: Implementation-specific parameters
         """
         pass
 

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -105,16 +105,12 @@ class StreamDiffusion(Pipeline):
             try:
                 if await self._update_params_dynamic(new_params):
                     return
-            except Exception as e:
+            except Exception:
                 logging.error(
-                    f"Error updating parameters dynamically: {e}",
+                    "Error updating parameters dynamically",
                     extra={
                         "report_error": True,
-                        "error_code": "SD_UPDATE_DYNAMIC_ERROR",
-                        "error_context": {
-                            "stage": "update_params.dynamic",
-                            "exception_type": type(e).__name__,
-                        },
+                        "error": "[update_params] Error updating params dynamically",
                     },
                     exc_info=True,
                 )
@@ -140,10 +136,7 @@ class StreamDiffusion(Pipeline):
                 "Error resetting pipeline, reloading with previous params",
                 extra={
                     "report_error": True,
-                    "error_code": "SD_PIPELINE_RESET_ERROR",
-                    "error_context": {
-                        "stage": "update_params.reset_initial",
-                    },
+                    "error": "[update_params] Error resetting pipeline; attempting fallback",
                 },
                 exc_info=True,
             )
@@ -155,13 +148,9 @@ class StreamDiffusion(Pipeline):
                     "Failed to reload pipeline with fallback params",
                     extra={
                         "report_error": True,
-                        "error_code": "SD_PIPELINE_RESET_FALLBACK_ERROR",
-                        "error_context": {
-                            "stage": "update_params.reset_fallback",
-                        },
+                        "error": "[update_params] Fallback reload failed",
                     },
                     exc_info=True,
-                    stack_info=True,
                 )
                 raise
 

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -105,13 +105,10 @@ class StreamDiffusion(Pipeline):
             try:
                 if await self._update_params_dynamic(new_params):
                     return
-            except Exception:
+            except Exception as e:
                 logging.error(
-                    "Error updating parameters dynamically",
-                    extra={
-                        "report_error": True,
-                        "error": "[update_params] Error updating params dynamically",
-                    },
+                    f"[update_params] Error updating params dynamically: {e}",
+                    extra={"report_error": True},
                     exc_info=True,
                 )
 
@@ -131,25 +128,19 @@ class StreamDiffusion(Pipeline):
         new_pipe: Optional[StreamDiffusionWrapper] = None
         try:
             new_pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
-        except Exception:
+        except Exception as e:
             logging.error(
-                "Error resetting pipeline, reloading with previous params",
-                extra={
-                    "report_error": True,
-                    "error": "[update_params] Error resetting pipeline; attempting fallback",
-                },
+                f"[update_params] Error resetting pipeline, reloading with previous params: {e}",
+                extra={"report_error": True},
                 exc_info=True,
             )
             try:
                 new_params = prev_params or StreamDiffusionParams()
                 new_pipe = await asyncio.to_thread(load_streamdiffusion_sync, new_params)
-            except Exception:
+            except Exception as e:
                 logging.error(
-                    "Failed to reload pipeline with fallback params",
-                    extra={
-                        "report_error": True,
-                        "error": "[update_params] Fallback reload failed",
-                    },
+                    f"[update_params] Fallback reload with previous params failed: {e}",
+                    extra={"report_error": True},
                     exc_info=True,
                 )
                 raise

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -354,13 +354,13 @@ class LogQueueHandler(logging.Handler):
         self.process = process
 
     def emit(self, record):
+        msg = self.format(record)
+        self.process._try_queue_put(self.process.log_queue, msg)
         try:
             if getattr(record, "report_error", False):
-                error_message = getattr(record, "error", None) or record.getMessage()
-                self.process._report_error(error_message)
-        finally:
-            msg = self.format(record)
-            self.process._try_queue_put(self.process.log_queue, msg)
+                self.process._report_error(record.getMessage())
+        except Exception as e:
+            logging.error(f"Error reporting error: {e}")
 
 # Function to clear the queue
 def clear_queue(queue):

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -356,23 +356,8 @@ class LogQueueHandler(logging.Handler):
     def emit(self, record):
         try:
             if getattr(record, "report_error", False):
-                message = record.getMessage()
-                error_code = getattr(record, "error_code", None)
-                error_context = getattr(record, "error_context", None)
-
-                parts = []
-                if error_code:
-                    parts.append(f"[{error_code}]")
-                parts.append(message)
-
-                if error_context is not None:
-                    try:
-                        ctx_json = json.dumps(error_context, sort_keys=True)
-                    except Exception:
-                        ctx_json = str(error_context)
-                    parts.append(f"context={ctx_json}")
-
-                self.process._report_error(" ".join(parts))
+                error_message = getattr(record, "error", None) or record.getMessage()
+                self.process._report_error(error_message)
         finally:
             msg = self.format(record)
             self.process._try_queue_put(self.process.log_queue, msg)

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -142,7 +142,7 @@ class PipelineProcess:
         try:
             asyncio.run(self._run_pipeline_loops())
         except Exception as e:
-            self._report_error(f"Error in process run method: {e}")
+            self._report_error("Error in process run method", e)
 
 
     def _handle_logging_params(self, params: dict) -> bool:
@@ -169,8 +169,7 @@ class PipelineProcess:
                 await pipeline.initialize(**params)
                 return pipeline
         except Exception as e:
-            self._report_error(f"Error loading pipeline: {e}")
-            logging.exception(e)
+            self._report_error("Error loading pipeline", e)
             if not params:
                 # Already tried loading with default params
                 raise
@@ -182,7 +181,7 @@ class PipelineProcess:
                     await pipeline.initialize()
                     return pipeline
             except Exception as e:
-                self._report_error(f"Error loading pipeline with default params: {e}")
+                self._report_error("Error loading pipeline with default params", e)
                 raise
 
     async def _run_pipeline_loops(self):
@@ -201,7 +200,7 @@ class PipelineProcess:
         try:
             await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except Exception as e:
-            self._report_error(f"Error in pipeline loops: {e}")
+            self._report_error("Error in pipeline loops", e)
         finally:
             for task in tasks:
                 task.cancel()
@@ -223,8 +222,7 @@ class PipelineProcess:
                 # Timeout ensures the non-daemon threads from to_thread can exit if task is cancelled
                 continue
             except Exception as e:
-                self._report_error(f"Error processing input frame: {e}")
-                logging.exception(e)
+                self._report_error("Error processing input frame", e)
 
     async def _output_loop(self, pipeline: Pipeline):
         while not self.is_done():
@@ -235,7 +233,7 @@ class PipelineProcess:
                 output.log_timestamps["post_process_frame"] = time.time()
                 self._try_queue_put(self.output_queue, output)
             except Exception as e:
-                self._report_error(f"Error processing output frame: {e}")
+                self._report_error("Error processing output frame", e)
 
     async def _param_update_loop(self, pipeline: Pipeline):
         while not self.is_done():
@@ -250,7 +248,7 @@ class PipelineProcess:
                 with log_timing(f"PipelineProcess: Pipeline update parameters with params_hash={params_hash}"):
                     await pipeline.update_params(**params)
             except Exception as e:
-                self._report_error(f"Error updating params: {e}")
+                self._report_error("Error updating params", e)
 
     async def _get_latest_params(self, timeout: float) -> dict | None:
         """
@@ -278,12 +276,14 @@ class PipelineProcess:
 
         return params
 
-    def _report_error(self, error_msg: str):
+    def _report_error(self, msg: str, error: Exception | None = None, silent = False):
+        if not silent:
+            logging.error(msg, exc_info=error)
+
         error_event = {
-            "message": error_msg,
+            "message": f"{msg}: {error}" if error else msg,
             "timestamp": time.time()
         }
-        logging.error(error_msg)
         self._try_queue_put(self.error_queue, error_event)
 
     async def _cleanup_pipeline(self, pipeline):
@@ -358,7 +358,7 @@ class LogQueueHandler(logging.Handler):
         self.process._try_queue_put(self.process.log_queue, msg)
         try:
             if getattr(record, "report_error", False):
-                self.process._report_error(record.getMessage())
+                self.process._report_error(record.getMessage(), silent=True)
         except Exception as e:
             logging.error(f"Error reporting error: {e}")
 


### PR DESCRIPTION
This makes sure we propagate internal errors when updating the parameters so that
feedback can be shown to the user. Made it through a special logging field to be added
when we want the error to go to the end user, like for the IPAdapter errors we are getting
in the library. This should not be abused as to become pure spam tho, only actionable/critical
or high-level errors should be reported to the user.