### PR TITLE
live/pipeline: Propagate loading state upwards

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -113,7 +113,9 @@ class StreamDiffusion(Pipeline):
                 )
 
         logging.info(f"Resetting pipeline for params change")
+        return asyncio.create_task(self._reload_pipeline(new_params))
 
+    async def _reload_pipeline(self, new_params: StreamDiffusionParams):
         try:
             await self._overlay_renderer.prewarm(new_params.width, new_params.height)
         except Exception:

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -29,7 +29,10 @@ class StreamDiffusion(Pipeline):
 
     async def initialize(self, **params):
         logging.info(f"Initializing StreamDiffusion pipeline with params: {params}")
-        await self.update_params(**params)
+        reload_task = await self.update_params(**params)
+        if reload_task:
+            logging.info("Task returned, waiting for pipeline reload")
+            await reload_task
         logging.info("Pipeline initialization complete")
 
     async def put_video_frame(self, frame: VideoFrame, request_id: str):

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -101,9 +101,6 @@ class PipelineProcess:
         self._try_queue_put(self.input_queue, frame)
 
     async def recv_output(self) -> OutputFrame | None:
-        # we cannot do a long get with timeout as that would block the asyncio
-        # event loop, so we loop with nowait and sleep async instead.
-        # TODO: use asyncio.to_thread instead
         while not self.is_done():
             try:
                 return await asyncio.to_thread(self.output_queue.get, timeout=0.1)
@@ -124,7 +121,6 @@ class PipelineProcess:
 
     def process_loop(self):
         self._setup_logging()
-        pipeline = None
 
         # Ensure CUDA environment is available inside the subprocess.
         # Multiprocessing (spawn mode) does not inherit environment variables by default,

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -276,6 +276,7 @@ class PipelineProcess:
                     self._set_pipeline_ready(True)
             except Exception as e:
                 self._report_error("Error reloading pipeline", e)
+                self.done.set()
                 os._exit(1) # shutdown the sub-process altogether
 
     async def _get_latest_params(self, timeout: float) -> dict | None:

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -16,9 +16,9 @@ from trickle import InputFrame, AudioFrame, VideoFrame, OutputFrame, VideoOutput
 
 class PipelineProcess:
     @staticmethod
-    def start(pipeline_name: str, params: dict):
+    def start(pipeline_name: str, params: dict | None = None):
         instance = PipelineProcess(pipeline_name)
-        if params:
+        if params is not None:
             instance.update_params(params)
         instance.process.start()
         instance.start_time = time.time()
@@ -152,7 +152,7 @@ class PipelineProcess:
 
     async def _initialize_pipeline(self):
         try:
-            params = await self._get_latest_params(timeout=0.005)
+            params = await self._get_latest_params(timeout=0.1)
             if params is not None:
                 logging.info(f"PipelineProcess: Got params from param_update_queue {params}")
             else:

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -152,7 +152,7 @@ class ProcessGuardian:
         if not self.process or not self.process.is_alive():
             logging.error("Process is not alive. Returning ERROR state")
             return PipelineState.ERROR
-        elif not self.process.is_pipeline_initialized() or self.process.done.is_set():
+        elif not self.process.is_pipeline_ready() or self.process.done.is_set():
             # done is only set in the middle of the restart process so also return INITIALIZING
             return PipelineState.LOADING
 

--- a/runner/app/live/streamer/process_guardian.py
+++ b/runner/app/live/streamer/process_guardian.py
@@ -152,16 +152,40 @@ class ProcessGuardian:
         if not self.process or not self.process.is_alive():
             logging.error("Process is not alive. Returning ERROR state")
             return PipelineState.ERROR
-        elif not self.process.is_pipeline_ready() or self.process.done.is_set():
-            # done is only set in the middle of the restart process so also return INITIALIZING
-            return PipelineState.LOADING
 
-        # Special case: stream not running
+        # Compute some state metrics
         current_time = time.time()
         input = self.status.input_status
         start_time = max(self.process.start_time, self.status.start_time)
         time_since_last_input = current_time - (input.last_input_time or start_time)
 
+        inference = self.status.inference_status
+        time_since_last_output = current_time - (inference.last_output_time or 0)
+        pipeline_load_time = max(inference.last_params_update_time or 0, start_time)
+        # -2s to be conservative and avoid race conditions on the timestamp comparisons below
+        time_since_pipeline_load = max(0, current_time - pipeline_load_time - 2)
+
+        # Special case: pipeline loading
+        is_process_loading = not self.process.is_pipeline_ready() or self.process.done.is_set()
+        active_after_load = time_since_last_output < time_since_pipeline_load
+        logging.debug(f"[_compute_current_state] is_process_loading={is_process_loading} active_after_load={active_after_load} time_since_last_output={time_since_last_output:.1f}s time_since_pipeline_load={time_since_pipeline_load:.1f}s")
+        if is_process_loading or not active_after_load:
+            # The pipeline process shouldn't stop for too long if it's not loading.
+            load_grace_period = 60 if is_process_loading else 1
+            load_timeout = 120 if is_process_loading else 10
+            # Do not propagate a LOADING state for quick stops (e.g. params updates).
+            healthy_state = PipelineState.LOADING if is_process_loading else PipelineState.ONLINE
+            return (
+                healthy_state
+                if time_since_pipeline_load < load_grace_period
+                else PipelineState.DEGRADED_INPUT
+                if time_since_last_input > time_since_pipeline_load
+                else PipelineState.DEGRADED_INFERENCE
+                if time_since_pipeline_load < load_timeout
+                else PipelineState.ERROR  # Not starting after timeout, declare ERROR
+            )
+
+        # Special case: stream not running
         if not self.streamer.is_stream_running():
             # give it 3s `DEGRADED_INPUT` grace period after shutdown
             is_offline = time_since_last_input > 3 or not input.last_input_time
@@ -178,29 +202,6 @@ class ProcessGuardian:
             # Stream hasn't shut down 30s after the trigger above (90s total idle time).
             # Declare ERROR so the container gets restarted by the worker.
             return PipelineState.ERROR
-
-        # Special case: pipeline load
-        inference = self.status.inference_status
-        time_since_last_output = current_time - (inference.last_output_time or 0)
-        pipeline_load_time = max(inference.last_params_update_time or 0, start_time)
-        # -2s to be conservative and avoid race conditions on the timestamp comparisons below
-        time_since_pipeline_load = max(0, current_time - pipeline_load_time - 2)
-
-        active_after_load = time_since_last_output < time_since_pipeline_load
-        logging.debug(f"[_compute_current_state] active_after_load={active_after_load} time_since_last_output={time_since_last_output:.1f}s time_since_pipeline_load={time_since_pipeline_load:.1f}s")
-        if not active_after_load:
-            is_params_update = (inference.last_params_update_time or 0) > start_time
-            load_grace_period = 2 if is_params_update else 10
-            load_timeout = 60 if is_params_update else 120
-            return (
-                PipelineState.ONLINE
-                if time_since_pipeline_load < load_grace_period
-                else PipelineState.DEGRADED_INPUT
-                if time_since_last_input > time_since_pipeline_load
-                else PipelineState.DEGRADED_INFERENCE
-                if time_since_pipeline_load < load_timeout
-                else PipelineState.ERROR  # Not starting after timeout, declare ERROR
-            )
 
         # Normal case: active stream
         stopped_producing_frames = (


### PR DESCRIPTION
This is to propagate the state of when the pipeline process is reloading the pipeline.

This is mainly useful for when the stream ends, where we reload the default params again.
In case these default params require a reload, this will now make sure that the Orchestrator
will not accept any streams while that reload is happening. 

This is the main PR for INF-297