### PR TITLE
Manage loading overlay in process.py

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -10,7 +10,6 @@ from io import BytesIO
 import aiohttp
 
 from .interface import Pipeline
-from .loading_overlay import LoadingOverlayRenderer
 from trickle import VideoFrame, VideoOutput
 
 from .streamdiffusion_params import StreamDiffusionParams, IPAdapterConfig, get_model_type, IPADAPTER_SUPPORTED_TYPES
@@ -23,7 +22,6 @@ class StreamDiffusion(Pipeline):
         self.first_frame = True
         self.frame_queue: asyncio.Queue[VideoOutput] = asyncio.Queue()
         self._pipeline_lock = asyncio.Lock()  # Protects pipeline initialization/reinitialization
-        self._overlay_renderer = LoadingOverlayRenderer()
         self._cached_style_image_tensor: Optional[torch.Tensor] = None
         self._cached_style_image_url: Optional[str] = None
 
@@ -40,13 +38,8 @@ class StreamDiffusion(Pipeline):
             raise RuntimeError("Pipeline not initialized")
 
         async with self._pipeline_lock:
-            loading_frame = await self._overlay_renderer.render_if_active(self.params.width, self.params.height)
-            if loading_frame is not None:
-                output = VideoOutput(frame, request_id, is_loading_frame=True).replace_tensor(loading_frame)
-            else:
-                out_tensor = await asyncio.to_thread(self.process_tensor_sync, frame.tensor)
-                output = VideoOutput(frame, request_id).replace_tensor(out_tensor)
-                self._overlay_renderer.update_last_frame(out_tensor)
+            out_tensor = await asyncio.to_thread(self.process_tensor_sync, frame.tensor)
+            output = VideoOutput(frame, request_id).replace_tensor(out_tensor)
 
         await self.frame_queue.put(output)
 
@@ -94,7 +87,6 @@ class StreamDiffusion(Pipeline):
             logging.info("No parameters changed")
             return
 
-        self._overlay_renderer.set_show_overlay(new_params.show_reloading_frame)
 
         # Pre-fetch the style image before locking. This raises any errors early (e.g. invalid URL or image) and also
         # allows us to fetch the style image without blocking inference with the lock.
@@ -119,16 +111,10 @@ class StreamDiffusion(Pipeline):
         return asyncio.create_task(self._reload_pipeline(new_params))
 
     async def _reload_pipeline(self, new_params: StreamDiffusionParams):
-        try:
-            await self._overlay_renderer.prewarm(new_params.width, new_params.height)
-        except Exception:
-            logging.warning("Failed to prewarm loading overlay caches", exc_info=True)
-
         async with self._pipeline_lock:
             # Clear the pipeline while loading the new one. The loading overlay will be shown while this is happening.
             self.pipe = None
             prev_params = self.params
-            self._overlay_renderer.begin_reload()
 
         new_pipe: Optional[StreamDiffusionWrapper] = None
         try:
@@ -150,7 +136,6 @@ class StreamDiffusion(Pipeline):
             self.pipe = new_pipe
             self.params = new_params
             self.first_frame = True
-            self._overlay_renderer.end_reload()
 
             if new_params.ip_adapter and new_params.ip_adapter.enabled:
                 await self._update_style_image(new_params)
@@ -254,8 +239,6 @@ class StreamDiffusion(Pipeline):
             self.pipe = None
             self.params = None
             self.frame_queue = asyncio.Queue()
-            self._overlay_renderer.end_reload()
-            self._overlay_renderer.reset_session(0.0)
 
 
 def _prepare_controlnet_configs(params: StreamDiffusionParams) -> Optional[List[Dict[str, Any]]]:


### PR DESCRIPTION
Centralize loading overlay management in `process.py` to simplify pipeline implementations and provide transparent overlay functionality for all pipelines.

The previous approach required each pipeline to manage its own `LoadingOverlayRenderer` instance and integrate its logic for showing/hiding the overlay during reloads and when the model was not ready. This PR moves all overlay-related logic to `process.py`, which already knows the pipeline's readiness state, making it a natural fit for managing the overlay. This significantly reduces boilerplate in individual pipelines and ensures consistent overlay behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-5046e1e7-e4db-41ad-a6fe-4da58458edcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5046e1e7-e4db-41ad-a6fe-4da58458edcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

