### PR TITLE
infer.py: Avoid leaving orphaned process behind

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -21,13 +21,23 @@ from streamer.protocol.trickle import TrickleProtocol, DEFAULT_WIDTH, DEFAULT_HE
 from streamer.protocol.zeromq import ZeroMQProtocol
 
 
+_UNCAUGHT_EXCEPTION_EVENT = asyncio.Event()
+_MAIN_LOOP: asyncio.AbstractEventLoop | None = None
+
+
 def asyncio_exception_handler(loop, context):
     """
     Handles unhandled exceptions in asyncio tasks, logging the error and terminating the application.
     """
     exception = context.get('exception')
-    logging.error(f"Terminating process due to unhandled exception in asyncio task", exc_info=exception)
-    os._exit(1)
+    logging.error(
+        f"Terminating process due to unhandled exception in asyncio task: {exception}",
+        exc_info=exception,
+    )
+    try:
+        _UNCAUGHT_EXCEPTION_EVENT.set()
+    except Exception:
+        os._exit(1)
 
 
 def thread_exception_hook(original_hook):
@@ -35,9 +45,15 @@ def thread_exception_hook(original_hook):
     Creates a custom exception hook for threads that logs the error and terminates the application.
     """
     def custom_hook(args):
-        logging.error("Terminating process due to unhandled exception in thread", exc_info=args.exc_value)
-        original_hook(args) # this is most likely a noop
-        os._exit(1)
+        logging.error(
+            f"Terminating process due to unhandled exception in thread: {args.exc_value}",
+            exc_info=args.exc_value,
+        )
+        original_hook(args)  # this is most likely a noop
+        try:
+            _MAIN_LOOP.call_soon_threadsafe(_UNCAUGHT_EXCEPTION_EVENT.set)  # type: ignore
+        except Exception:
+            os._exit(1)
     return custom_hook
 
 
@@ -55,8 +71,9 @@ async def main(
     manifest_id: str,
     stream_id: str,
 ):
-    loop = asyncio.get_event_loop()
-    loop.set_exception_handler(asyncio_exception_handler)
+    global _MAIN_LOOP
+    _MAIN_LOOP = asyncio.get_event_loop()
+    _MAIN_LOOP.set_exception_handler(asyncio_exception_handler)
 
     process = ProcessGuardian(pipeline, params or {})
     # Only initialize the streamer if we have a protocol and URLs to connect to
@@ -72,7 +89,9 @@ async def main(
             protocol = ZeroMQProtocol(subscribe_url, publish_url)
         else:
             raise ValueError(f"Unsupported protocol: {stream_protocol}")
-        streamer = PipelineStreamer(protocol, process, request_id, stream_id)
+        streamer = PipelineStreamer(
+            protocol, process, request_id, manifest_id, stream_id
+        )
 
     api = None
     try:
@@ -82,25 +101,39 @@ async def main(
                 await streamer.start(params)
             api = await start_http_server(http_port, process, streamer)
 
-        tasks: List[asyncio.Task] = []
-        if streamer:
-            tasks.append(asyncio.create_task(streamer.wait()))
-        tasks.append(
-            asyncio.create_task(block_until_signal([signal.SIGINT, signal.SIGTERM]))
-        )
+        async def wait_uncaught():
+            await _UNCAUGHT_EXCEPTION_EVENT.wait()
+            logging.error(
+                "Uncaught exception event received. Initiating graceful shutdown."
+            )
 
-        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        lifecycle_tasks: List[asyncio.Task] = [
+            asyncio.create_task(block_until_signal([signal.SIGINT, signal.SIGTERM])),
+            asyncio.create_task(wait_uncaught()),
+        ]
+        if streamer:
+            lifecycle_tasks.append(asyncio.create_task(streamer.wait()))
+
+        await asyncio.wait(lifecycle_tasks, return_when=asyncio.FIRST_COMPLETED)
     except Exception as e:
         logging.error(f"Error starting socket handler or HTTP server: {e}")
         logging.error(f"Stack trace:\n{traceback.format_exc()}")
         raise e
     finally:
+        stop_coros: List[asyncio._CoroutineLike] = [
+            process.stop(),
+        ]
         if streamer:
             streamer.trigger_stop_stream()
-            await streamer.wait(timeout=5)
+            stop_coros.append(streamer.wait())
         if api:
-            await api.cleanup()
-        await process.stop()
+            stop_coros.append(api.cleanup())
+
+        try:
+            stops = asyncio.gather(*stop_coros, return_exceptions=True)
+            await asyncio.wait_for(stops, timeout=20)
+        except Exception:
+            os._exit(1)
 
 
 async def block_until_signal(sigs: List[signal.Signals]):

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -131,8 +131,12 @@ async def main(
 
         try:
             stops = asyncio.gather(*stop_coros, return_exceptions=True)
-            await asyncio.wait_for(stops, timeout=20)
-        except Exception:
+            results = await asyncio.wait_for(stops, timeout=10)
+            exceptions = [result for result in results if isinstance(result, Exception)]
+            if exceptions:
+                raise ExceptionGroup("Error stopping components", exceptions)
+        except Exception as e:
+            logging.error(f"Graceful shutdown error, exiting abruptly: {e}", exc_info=True)
             os._exit(1)
 
 

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -71,10 +71,10 @@ class PipelineProcess:
                     logging.error(f"Process join error: {e}")
                     return False
 
-            if not await wait_stop(10):
+            if not await wait_stop(5):
                 logging.error("Failed to terminate process, killing")
                 self.process.kill()
-                if not await wait_stop(5):
+                if not await wait_stop(3):
                     logging.error("Failed to kill process")
 
         logging.info("Pipeline process terminated, closing queues")

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -86,6 +86,9 @@ class PipelineProcess:
         logging.info("Pipeline process cleanup complete")
 
     async def _wait_stop(self, timeout: float) -> bool:
+        """
+        Wait for the process to stop and return True if it did, False otherwise.
+        """
         try:
             await asyncio.to_thread(self.process.join, timeout=timeout)
             return not self.process.is_alive()

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -71,13 +71,10 @@ class PipelineProcess:
                 is_terminating = False
 
         logging.info("Closing process queues")
-        for queue_name in ["input_queue", "output_queue", "param_update_queue", "error_queue", "log_queue"]:
-            q: mp.Queue | None = getattr(self, queue_name)
-            if q is None:
-                continue
+        for q in [self.input_queue, self.output_queue, self.param_update_queue,
+                  self.error_queue, self.log_queue]:
             q.cancel_join_thread()
             q.close()
-            setattr(self, queue_name, None)
 
         if is_terminating and self.is_alive():
             logging.error("Failed to terminate process, killing")

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -77,7 +77,7 @@ class PipelineProcess:
 
                 self.process.kill()
                 if not await wait_stop(3):
-                    logging.error(f"Failed to kill process parent_pid={os.getppid()} pid={self.process.pid} is_alive={self.process.is_alive()}")
+                    logging.error(f"Failed to kill process self_pid={os.getpid()} child_pid={self.process.pid} is_alive={self.process.is_alive()}")
                     raise RuntimeError("Failed to kill process")
 
         logging.info("Pipeline process terminated, closing queues")

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -71,11 +71,14 @@ class PipelineProcess:
                     logging.error(f"Process join error: {e}")
                     return False
 
+            self.process.terminate()
             if not await wait_stop(5):
                 logging.error("Failed to terminate process, killing")
+
                 self.process.kill()
                 if not await wait_stop(3):
-                    logging.error("Failed to kill process")
+                    logging.error(f"Failed to kill process parent_pid={os.getppid()} pid={self.process.pid} is_alive={self.process.is_alive()}")
+                    raise RuntimeError("Failed to kill process")
 
         logging.info("Pipeline process terminated, closing queues")
 

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -34,7 +34,7 @@ class LiveVideoToVideoPipeline(Pipeline):
     ):
         if not self.process:
             raise RuntimeError("Pipeline process not running")
-        
+
         max_retries = 10
         thrown_ex = None
         for attempt in range(max_retries):
@@ -158,10 +158,10 @@ class LiveVideoToVideoPipeline(Pipeline):
             self.log_process_diagnostics(full=True)
             break
 
-        self.restart_count += 1
-        if self.restart_count > 10:
-            logging.error("infer.py process has restarted more than 10 times. Exiting.")
+        if self.restart_count >= 3:
+            logging.error("infer.py process has crashed more than 3 times. Exiting.")
             os._exit(1)
+        self.restart_count += 1
 
         # Start a separate thread to restart the process since it will
         # restart the monitor thread itself (the current thread).


### PR DESCRIPTION
This is to avoid having the pipeline process resist a restart when the parent process dies for any reason.

Fixed this in 2 ways:
- Ensure we gracefully stop the process guardian when we have an uncaught exception (cause of orphaned process recently)
- Make pipeline process kill itself when it notices the parent process is gone. This is implemented with a unix signal and a wathdog thread

Fixes INF-350