### PR TITLE
Fix local imports in live folder

### DIFF
--- a/runner/app/live/api/api.py
+++ b/runner/app/live/api/api.py
@@ -10,11 +10,11 @@ from aiohttp import web
 from pydantic import BaseModel, Field
 from typing import Annotated, Dict
 
-from log import config_logging
-from process import ProcessGuardian
-from streamer import PipelineStreamer
-from streamer.protocol import TrickleProtocol
-from trickle import DEFAULT_WIDTH, DEFAULT_HEIGHT
+from ..log import config_logging
+from ..process import ProcessGuardian
+from ..streamer import PipelineStreamer
+from ..streamer.protocol import TrickleProtocol
+from ..trickle import DEFAULT_WIDTH, DEFAULT_HEIGHT
 
 MAX_FILE_AGE = 86400  # 1 day
 

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -9,16 +9,12 @@ import traceback
 import threading
 from typing import List
 
-# loads neighbouring modules with absolute paths
-infer_root = os.path.abspath(os.path.dirname(__file__))
-sys.path.insert(0, infer_root)
-
-from process import ProcessGuardian
-from streamer import PipelineStreamer
-from streamer.protocol import TrickleProtocol, ZeroMQProtocol
-from streamer.protocol.trickle import DEFAULT_WIDTH, DEFAULT_HEIGHT
-from api import start_http_server
-from log import config_logging, log_timing
+from .process import ProcessGuardian
+from .streamer import PipelineStreamer
+from .streamer.protocol import TrickleProtocol, ZeroMQProtocol
+from .trickle import DEFAULT_WIDTH, DEFAULT_HEIGHT
+from .api import start_http_server
+from .log import config_logging, log_timing
 
 
 _UNCAUGHT_EXCEPTION_EVENT = asyncio.Event()

--- a/runner/app/live/pipelines/comfyui.py
+++ b/runner/app/live/pipelines/comfyui.py
@@ -8,7 +8,7 @@ import pathlib
 
 from .interface import Pipeline, BaseParams
 from comfystream.client import ComfyStreamClient
-from trickle import VideoFrame, VideoOutput
+from ..trickle import VideoFrame, VideoOutput
 
 import logging
 

--- a/runner/app/live/pipelines/interface.py
+++ b/runner/app/live/pipelines/interface.py
@@ -1,7 +1,7 @@
 from asyncio import Task
 from abc import ABC, abstractmethod
 from pydantic import BaseModel, Field
-from trickle import VideoFrame, VideoOutput, DEFAULT_WIDTH, DEFAULT_HEIGHT
+from ..trickle import VideoFrame, VideoOutput, DEFAULT_WIDTH, DEFAULT_HEIGHT
 
 
 class BaseParams(BaseModel):

--- a/runner/app/live/pipelines/noop.py
+++ b/runner/app/live/pipelines/noop.py
@@ -2,7 +2,7 @@ import logging
 import asyncio
 
 from .interface import Pipeline
-from trickle import VideoFrame, VideoOutput
+from ..trickle import VideoFrame, VideoOutput
 
 class Noop(Pipeline):
   def __init__(self):

--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -10,7 +10,7 @@ from io import BytesIO
 import aiohttp
 
 from .interface import Pipeline
-from trickle import VideoFrame, VideoOutput
+from ..trickle import VideoFrame, VideoOutput
 
 from .streamdiffusion_params import StreamDiffusionParams, IPAdapterConfig, get_model_type, IPADAPTER_SUPPORTED_TYPES
 

--- a/runner/app/live/process/process.py
+++ b/runner/app/live/process/process.py
@@ -13,9 +13,9 @@ from typing import Any
 
 import torch
 
-from pipelines import load_pipeline, Pipeline, BaseParams
-from log import config_logging, config_logging_fields, log_timing
-from trickle import (
+from ..pipelines import load_pipeline, Pipeline, BaseParams
+from ..log import config_logging, config_logging_fields, log_timing
+from ..trickle import (
     InputFrame,
     AudioFrame,
     VideoFrame,

--- a/runner/app/live/process/process_guardian.py
+++ b/runner/app/live/process/process_guardian.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 import abc
 
-from trickle import InputFrame, OutputFrame
+from ..trickle import InputFrame, OutputFrame
 from .process import PipelineProcess
 from .status import PipelineState, PipelineStatus, InferenceStatus, InputStatus
 

--- a/runner/app/live/streamer/protocol/protocol.py
+++ b/runner/app/live/streamer/protocol/protocol.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncGenerator
 from PIL import Image
 
-from trickle import InputFrame, OutputFrame
+from ...trickle import InputFrame, OutputFrame
 
 class StreamProtocol(ABC):
     @abstractmethod

--- a/runner/app/live/streamer/protocol/trickle.py
+++ b/runner/app/live/streamer/protocol/trickle.py
@@ -6,7 +6,7 @@ from typing import AsyncGenerator, Optional
 
 from PIL import Image
 
-from trickle import media, TricklePublisher, TrickleSubscriber, InputFrame, OutputFrame, AudioFrame, AudioOutput, DEFAULT_WIDTH, DEFAULT_HEIGHT
+from ...trickle import media, TricklePublisher, TrickleSubscriber, InputFrame, OutputFrame, AudioFrame, AudioOutput, DEFAULT_WIDTH, DEFAULT_HEIGHT
 
 from .protocol import StreamProtocol
 from .last_value_cache import LastValueCache

--- a/runner/app/live/streamer/protocol/zeromq.py
+++ b/runner/app/live/streamer/protocol/zeromq.py
@@ -9,7 +9,7 @@ from PIL import Image
 import numpy as np
 import torch
 
-from trickle import InputFrame, VideoOutput
+from ...trickle import InputFrame, VideoOutput
 from .protocol import StreamProtocol
 
 TIME_BASE = Fraction(1, 90000)

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -5,9 +5,9 @@ import time
 from typing import AsyncGenerator, Awaitable
 from asyncio import Lock
 
-from trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutput
-from process import ProcessGuardian, StreamerCallbacks
-from process.status import timestamp_to_ms
+from ..trickle import AudioFrame, VideoFrame, OutputFrame, AudioOutput, VideoOutput
+from ..process import ProcessGuardian, StreamerCallbacks
+from ..process.status import timestamp_to_ms
 
 from .protocol.protocol import StreamProtocol
 


### PR DESCRIPTION
Remove `sys.path` monkey patch in `infer.py` and convert all local imports within the `live/` package to relative paths to improve module encapsulation and portability.

---
<a href="https://cursor.com/background-agent?bcId=bc-143a2ed5-7729-48b0-ae2b-dcd73d993a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-143a2ed5-7729-48b0-ae2b-dcd73d993a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

