### PR TITLE
dl_checkpoints: Fix tensorrt script module call and imports

### DIFF
--- a/runner/app/tools/__init__.py
+++ b/runner/app/tools/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer for runner.app.tools

--- a/runner/app/tools/streamdiffusion/__init__.py
+++ b/runner/app/tools/streamdiffusion/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer for runner.app.tools.streamdiffusion

--- a/runner/app/tools/streamdiffusion/build_tensorrt.py
+++ b/runner/app/tools/streamdiffusion/build_tensorrt.py
@@ -1,13 +1,8 @@
 import argparse
 from typing import List
 
-# Make sure 'infer.py' root folder is in PYTHONPATH
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..", "..", "live")))
-
-from pipelines.streamdiffusion_params import StreamDiffusionParams, ControlNetConfig, IPAdapterConfig
-from pipelines.streamdiffusion import load_streamdiffusion_sync
+from ...live.pipelines.streamdiffusion_params import StreamDiffusionParams, ControlNetConfig, IPAdapterConfig
+from ...live.pipelines.streamdiffusion import load_streamdiffusion_sync
 
 def create_controlnet_configs(controlnet_model_ids: List[str]) -> List[ControlNetConfig]:
     """

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -102,14 +102,9 @@ if [ ! -f "$CONDA_PYTHON" ]; then
     exit 1
 fi
 
-# Check if the build script exists
+# Build script module path (execute via python -m)
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-BUILD_SCRIPT="$SCRIPT_DIR/build_tensorrt.py"
-if [ ! -f "$BUILD_SCRIPT" ]; then
-    echo "ERROR: Build script not found at $BUILD_SCRIPT"
-    echo "Make sure the StreamDiffusion build script is available in the same directory as this script."
-    exit 1
-fi
+BUILD_SCRIPT_MODULE="runner.app.tools.streamdiffusion.build_tensorrt"
 
 # Create output directory
 echo "Creating output directory: $OUTPUT_DIR"
@@ -201,7 +196,7 @@ for model in $MODELS; do
                 --ipadapter-type "$ip_type"
             )
 
-            if $CONDA_PYTHON "$BUILD_SCRIPT" "${build_args[@]}"; then
+            if $CONDA_PYTHON -m "$BUILD_SCRIPT_MODULE" "${build_args[@]}"; then
                 echo "  ✓ Success"
             else
                 echo "  ✗ Failed"

--- a/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
+++ b/runner/app/tools/streamdiffusion/build_tensorrt_internal.sh
@@ -104,7 +104,11 @@ fi
 
 # Build script module path (execute via python -m)
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-BUILD_SCRIPT_MODULE="runner.app.tools.streamdiffusion.build_tensorrt"
+BUILD_SCRIPT_MODULE="app.tools.streamdiffusion.build_tensorrt"
+
+# Ensure Python can find the top-level 'app' package regardless of cwd
+APP_WORKSPACE="$(readlink -f "$SCRIPT_DIR/../../..")"
+export PYTHONPATH="$APP_WORKSPACE:${PYTHONPATH:-}"
 
 # Create output directory
 echo "Creating output directory: $OUTPUT_DIR"


### PR DESCRIPTION
Enable `build_tensorrt.py` to be run as a Python module and fix its imports to be relative, addressing issue #813 and improving package structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-df82f494-7734-45d1-b5ca-83f5c5804da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df82f494-7734-45d1-b5ca-83f5c5804da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable running `build_tensorrt.py` via `python -m app.tools.streamdiffusion.build_tensorrt`, switch to package-relative imports, update internal script to use module and set PYTHONPATH, and add package initializers.
> 
> - **Tools/StreamDiffusion**:
>   - **Module execution**: Update `build_tensorrt_internal.sh` to call `python -m app.tools.streamdiffusion.build_tensorrt` and export `PYTHONPATH` for the top-level `app` package.
>   - **Imports**: Change `build_tensorrt.py` to use package-relative imports from `...live.pipelines` and remove ad-hoc `sys.path` manipulation.
>   - **Packaging**: Add `__init__.py` in `runner/app/tools/` and `runner/app/tools/streamdiffusion/` to ensure proper module discovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5af4da0b9a5f61b1d9d9adf77054fb4d9160e767. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->